### PR TITLE
fix: requirements db-driver

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,7 @@ starlette==0.40.0
 # DB と ORM
 sqlalchemy==2.0.41
 alembic==1.16.4
+psycopg[binary,pool]>=3.1.8
 asyncpg  
 
 # データ検証と設定
@@ -24,3 +25,4 @@ Mako==1.3.2
 MarkupSafe==2.1.5
 sniffio==1.3.1
 typing_extensions==4.14.1
+psycopg2-binary


### PR DESCRIPTION
psycopg[binary,pool]>=3.1.8を利用