### PR TITLE
Feature/issue ダッシュボード検索・ソート・フィルター機能の実装

### DIFF
--- a/app/crud/__init__.py
+++ b/app/crud/__init__.py
@@ -1,4 +1,4 @@
 from .crud_staff import staff
 from .crud_office import crud_office as office
 from .crud_office_staff import office_staff
-from .crud_dashboard import dashboard_crud as dashboard
+from .crud_dashboard import crud_dashboard as dashboard

--- a/app/crud/crud_dashboard.py
+++ b/app/crud/crud_dashboard.py
@@ -1,97 +1,217 @@
+from datetime import date, timedelta
 import uuid
-from typing import List, Optional, Tuple
+from typing import List, Optional
+import re
+from sqlalchemy import select, or_, and_, func, asc, desc, true
 from sqlalchemy.ext.asyncio import AsyncSession
-from sqlalchemy import select, func, and_
-from sqlalchemy.orm import selectinload
+from sqlalchemy.orm import joinedload, selectinload
+# import logging
 
-from app.models.staff import Staff
-from app.models.office import Office, OfficeStaff
-from app.models.welfare_recipient import WelfareRecipient, OfficeWelfareRecipient
-from app.models.support_plan_cycle import SupportPlanCycle
+from app.crud.base import CRUDBase
+from app.models import WelfareRecipient, OfficeWelfareRecipient, SupportPlanCycle, SupportPlanStatus, Staff, Office, OfficeStaff
+from app.schemas.dashboard import DashboardSummary
+from app.models.enums import SupportPlanStep
 
 
-class CRUDDashboard:
-    async def _ensure_db_open(self, db: Optional[AsyncSession] = None) -> None:
-        """
-        Ensure the provided DB session (or self.db) is available and not closed.
-        Raise a clear Exception if missing/closed so callers/tests observe failures.
-        """
-        check_db = db if db is not None else getattr(self, "db", None)
-        if check_db is None:
-            raise Exception("Database session is required")
-        # Only treat explicit boolean `closed == True` as closed.
-        # Some test fixtures provide MagicMock objects whose `.closed` is not a bool,
-        # so avoid treating non-bool values as "closed".
-        closed_val = getattr(check_db, "closed", False)
-        if isinstance(closed_val, bool) and closed_val:
-            raise Exception("Database session is closed")
-
-    async def get_staff_office(self, db: Optional[AsyncSession] = None, staff_id: Optional[uuid.UUID] = None):
-        """
-        スタッフのプライマリ事業所を取得。
-        テストや呼び出し側が db をキーワード引数で渡すことを想定。
-        """
-        await self._ensure_db_open(db)
-        query = (
-            select(Staff, Office)
-            .join(OfficeStaff, Staff.id == OfficeStaff.staff_id)
-            .join(Office, Office.id == OfficeStaff.office_id)
-            .where(
-                and_(
-                    Staff.id == staff_id,
-                    OfficeStaff.is_primary == True
-                )
-            )
-        )
-        result = await db.execute(query)
-        return result.one_or_none()
-
-    async def get_office_recipients(self, db: AsyncSession, *, office_id: uuid.UUID) -> List[WelfareRecipient]:
-        """オフィスに所属する利用者の情報を取得"""
-        query = (
-            select(WelfareRecipient)
-            .join(OfficeWelfareRecipient, WelfareRecipient.id == OfficeWelfareRecipient.welfare_recipient_id)
-            .where(OfficeWelfareRecipient.office_id == office_id)
-            .options(
-                selectinload(WelfareRecipient.support_plan_cycles).selectinload(SupportPlanCycle.statuses)
-            )
-        )
-        result = await db.execute(query)
-        return list(result.scalars().all())
-
-    async def get_latest_cycle(self, db: AsyncSession, *, welfare_recipient_id: uuid.UUID) -> Optional[SupportPlanCycle]:
-        """最新の支援計画サイクルを取得"""
-        query = (
-            select(SupportPlanCycle)
-            .where(
-                and_(
-                    SupportPlanCycle.welfare_recipient_id == welfare_recipient_id,
-                    SupportPlanCycle.is_latest_cycle == True
-                )
-            )
-            .options(selectinload(SupportPlanCycle.statuses))
-        )
-        result = await db.execute(query)
-        return result.scalar_one_or_none()
-
-    async def count_office_recipients(self, db: AsyncSession, *, office_id: uuid.UUID) -> int:
-        """オフィスに所属する利用者の数をカウント"""
-        query = (
-            select(func.count())
-            .select_from(OfficeWelfareRecipient)
-            .where(OfficeWelfareRecipient.office_id == office_id)
-        )
-        result = await db.execute(query)
-        return result.scalar() or 0
-
+class CRUDDashboard(CRUDBase[WelfareRecipient, DashboardSummary, DashboardSummary]):
     async def get_cycle_count_for_recipient(self, db: AsyncSession, *, welfare_recipient_id: uuid.UUID) -> int:
-        """利用者の支援計画サイクルの数を取得"""
+        """
+        特定の利用者の支援計画サイクルの総数を取得します。
+        """
         query = (
             select(func.count())
             .select_from(SupportPlanCycle)
             .where(SupportPlanCycle.welfare_recipient_id == welfare_recipient_id)
         )
         result = await db.execute(query)
-        return result.scalar() or 0
+        return result.scalar_one()
 
-dashboard_crud = CRUDDashboard()
+    async def get_latest_cycle(self, db: AsyncSession, *, welfare_recipient_id: uuid.UUID) -> Optional[SupportPlanCycle]:
+        """
+        特定の利用者の最新の支援計画サイクル（関連ステータスも含む）を取得します。
+        """
+        query = (
+            select(SupportPlanCycle)
+            .where(
+                SupportPlanCycle.welfare_recipient_id == welfare_recipient_id,
+                SupportPlanCycle.is_latest_cycle == True
+            )
+            .options(selectinload(SupportPlanCycle.statuses))
+        )
+        result = await db.execute(query)
+        return result.scalar_one_or_none()
+
+    async def get_staff_office(self, db: AsyncSession, *, staff_id: uuid.UUID) -> Optional[tuple[Staff, Office]]:
+        """
+        スタッフとその所属事業所を取得します。
+        """
+        query = (
+            select(Staff, Office)
+            .join(OfficeStaff, Staff.id == OfficeStaff.staff_id)
+            .join(Office, OfficeStaff.office_id == Office.id)
+            .where(
+                Staff.id == staff_id,
+                OfficeStaff.is_primary == True
+            )
+        )
+        result = await db.execute(query)
+        row = result.first()
+        return (row[0], row[1]) if row else None
+
+    async def get_office_recipients(self, db: AsyncSession, *, office_id: uuid.UUID) -> List[WelfareRecipient]:
+        """
+        指定された事業所の利用者一覧を取得します。
+        """
+        query = (
+            select(WelfareRecipient)
+            .join(OfficeWelfareRecipient)
+            .where(OfficeWelfareRecipient.office_id == office_id)
+        )
+        result = await db.execute(query)
+        return list(result.scalars().all())
+
+    async def count_office_recipients(self, db: AsyncSession, *, office_id: uuid.UUID) -> int:
+        """
+        指定された事業所の利用者数を取得します。
+        """
+        query = (
+            select(func.count())
+            .select_from(WelfareRecipient)
+            .join(OfficeWelfareRecipient)
+            .where(OfficeWelfareRecipient.office_id == office_id)
+        )
+        result = await db.execute(query)
+        return result.scalar_one()
+
+    async def get_filtered_summaries(
+        self,
+        db: AsyncSession,
+        *,
+        office_ids: List[str],
+        sort_by: str,
+        sort_order: str,
+        filters: dict,
+        search_term: Optional[str],
+        skip: int,
+        limit: int,
+    ) -> List[WelfareRecipient]:
+        print(
+            "get_filtered_summaries called: office_ids=%s sort_by=%s sort_order=%s filters=%s search_term=%s skip=%s limit=%s",
+            office_ids, sort_by, sort_order, filters, search_term, skip, limit
+        )
+        stmt = (
+            select(WelfareRecipient)
+            .join(OfficeWelfareRecipient)
+            .where(OfficeWelfareRecipient.office_id.in_(office_ids))
+        )
+
+        # --- 検索 ---
+        if search_term:
+            search_words = re.split(r'[\s　]+', search_term.strip())
+            conditions = []
+            for word in search_words:
+                if not word:
+                    continue
+                name_conditions = or_(
+                    WelfareRecipient.last_name.ilike(f"%{word}%"),
+                    WelfareRecipient.first_name.ilike(f"%{word}%"),
+                    WelfareRecipient.last_name_furigana.ilike(f"%{word}%"),
+                    WelfareRecipient.first_name_furigana.ilike(f"%{word}%"),
+                )
+                conditions.append(name_conditions)
+            if conditions:
+                stmt = stmt.where(and_(*conditions))
+
+        # --- JOINの決定と実行 ---
+        needs_cycle_outer_join = any(k in filters for k in ["is_overdue", "is_upcoming", "status", "cycle_number"])
+        needs_cycle_inner_join = sort_by == "next_renewal_deadline"
+
+        if needs_cycle_inner_join:
+            stmt = stmt.join(
+                SupportPlanCycle,
+                and_(
+                    WelfareRecipient.id == SupportPlanCycle.welfare_recipient_id,
+                    SupportPlanCycle.is_latest_cycle == true(),
+                ),
+            )
+        elif needs_cycle_outer_join:
+            stmt = stmt.outerjoin(
+                SupportPlanCycle,
+                and_(
+                    WelfareRecipient.id == SupportPlanCycle.welfare_recipient_id,
+                    SupportPlanCycle.is_latest_cycle == True,
+                ),
+            )
+
+        # --- フィルター ---
+        if filters:
+            if filters.get("is_overdue"):
+                stmt = stmt.where(SupportPlanCycle.next_renewal_deadline < date.today())
+            if filters.get("is_upcoming"):
+                stmt = stmt.where(
+                    SupportPlanCycle.next_renewal_deadline.between(
+                        date.today(), date.today() + timedelta(days=30)
+                    )
+                )
+            if filters.get("status"):
+                latest_status_subq = (
+                    select(
+                        SupportPlanStatus.plan_cycle_id,
+                        SupportPlanStatus.step_type,
+                        func.row_number().over(
+                            partition_by=SupportPlanStatus.plan_cycle_id,
+                            order_by=SupportPlanStatus.created_at.desc()
+                        ).label("rn")
+                    )
+                    .join(SupportPlanCycle, SupportPlanStatus.plan_cycle_id == SupportPlanCycle.id)
+                    .where(SupportPlanCycle.is_latest_cycle == True)
+                    .subquery("latest_status_subq")
+                )
+                # The join to SupportPlanCycle is already done above, so we join the subquery
+                stmt = stmt.join(
+                    latest_status_subq,
+                    latest_status_subq.c.plan_cycle_id == SupportPlanCycle.id
+                ).where(
+                    and_(
+                        latest_status_subq.c.rn == 1,
+                        latest_status_subq.c.step_type == filters["status"]
+                    )
+                )
+            if filters.get("cycle_number"):
+                stmt = stmt.where(SupportPlanCycle.cycle_number == filters["cycle_number"])
+
+        # --- ソート ---
+        if sort_by == "name_phonetic":
+            sort_column = func.concat(WelfareRecipient.last_name_furigana, WelfareRecipient.first_name_furigana)
+            order_func = sort_column.desc().nullslast() if sort_order == "desc" else sort_column.asc().nullsfirst()
+            stmt = stmt.order_by(order_func)
+        elif sort_by == "created_at":
+            sort_column = WelfareRecipient.created_at
+            order_func = sort_column.desc().nullslast() if sort_order == "desc" else sort_column.asc().nullsfirst()
+            stmt = stmt.order_by(order_func)
+        elif sort_by == "next_renewal_deadline":
+            sort_column = SupportPlanCycle.next_renewal_deadline
+            order_func = sort_column.desc().nullslast() if sort_order == "desc" else sort_column.asc().nullsfirst()
+            stmt = stmt.order_by(order_func)
+        else: # Default sort
+            default_sort_col = func.concat(WelfareRecipient.last_name_furigana, WelfareRecipient.first_name_furigana)
+            stmt = stmt.order_by(default_sort_col.asc().nullsfirst())
+
+        # --- イージアローディング、ページネーション、および実行 ---
+        stmt = stmt.options(
+            selectinload(WelfareRecipient.support_plan_cycles).selectinload(
+                SupportPlanCycle.statuses
+            )
+        ).offset(skip).limit(limit)
+
+        try:
+            print("Compiled stmt: %s", str(stmt))
+        except Exception:
+            print("Could not stringify stmt")
+
+        result = await db.execute(stmt)
+        rows = list(result.scalars().all())
+        print("get_filtered_summaries result count: %d", len(rows))
+        return rows
+
+crud_dashboard = CRUDDashboard(WelfareRecipient)

--- a/app/models/__init__.py
+++ b/app/models/__init__.py
@@ -6,3 +6,5 @@ from .enums import (
 from .office import Office, OfficeStaff
 from .staff import Staff #, PasswordResetToken
 from .mfa import MFABackupCode, MFAAuditLog
+from .welfare_recipient import WelfareRecipient, OfficeWelfareRecipient
+from .support_plan_cycle import SupportPlanCycle, SupportPlanStatus

--- a/app/models/welfare_recipient.py
+++ b/app/models/welfare_recipient.py
@@ -1,8 +1,9 @@
 import datetime
 import uuid
+import uuid
 from typing import List, TYPE_CHECKING
 
-from sqlalchemy import DateTime, ForeignKey, String, func
+from sqlalchemy import DateTime, ForeignKey, String, text, func
 from sqlalchemy.dialects.postgresql import UUID
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 from sqlalchemy import Enum as SQLAlchemyEnum
@@ -19,10 +20,11 @@ if TYPE_CHECKING:
 class WelfareRecipient(Base):
     """受給者"""
     __tablename__ = 'welfare_recipients'
-    id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, server_default=func.gen_random_uuid())
+    id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
     first_name: Mapped[str] = mapped_column(String(255))
     last_name: Mapped[str] = mapped_column(String(255))
-    furigana: Mapped[str] = mapped_column(String(255))
+    first_name_furigana: Mapped[str] = mapped_column(String(255))
+    last_name_furigana: Mapped[str] = mapped_column(String(255))
     birth_day: Mapped[datetime.date]
     gender: Mapped[GenderType] = mapped_column(SQLAlchemyEnum(GenderType))
     created_at: Mapped[datetime.datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
@@ -37,7 +39,7 @@ class WelfareRecipient(Base):
 class OfficeWelfareRecipient(Base):
     """事業所と受給者の中間テーブル"""
     __tablename__ = 'office_welfare_recipients'
-    id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, server_default=func.gen_random_uuid())
+    id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
     welfare_recipient_id: Mapped[uuid.UUID] = mapped_column(ForeignKey('welfare_recipients.id'))
     office_id: Mapped[uuid.UUID] = mapped_column(ForeignKey('offices.id'))
     created_at: Mapped[datetime.datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())

--- a/app/schemas/dashboard.py
+++ b/app/schemas/dashboard.py
@@ -19,7 +19,7 @@ class DashboardBase(BaseModel):
 
 
 # --- レスポンスモデル ---
-class DashboardRecipient(BaseModel):
+class DashboardSummary(BaseModel):
     """ダッシュボード:利用者情報"""
     # Use str so tests (and JSON output) compare IDs as strings.
     id: str
@@ -49,7 +49,7 @@ class DashboardRecipient(BaseModel):
 
 class DashboardData(DashboardBase):
     """ダッシュボード情報（レスポンス）"""
-    recipients: List[DashboardRecipient]
+    recipients: List[DashboardSummary]
 
     model_config = ConfigDict(from_attributes=True)
 

--- a/tests/api/v1/test_dashboard.py
+++ b/tests/api/v1/test_dashboard.py
@@ -29,7 +29,14 @@ async def dashboard_fixtures(db_session: AsyncSession, service_admin_user_factor
     
     recipients = []
     for i in range(3):
-        recipient = WelfareRecipient(first_name=f"太郎{i+1}", last_name="田中", furigana=f"たなか たろう{i+1}", birth_day=date(1990, 1, 1), gender=GenderType.male)
+        recipient = WelfareRecipient(
+            first_name=f"太郎{i+1}", 
+            last_name="田中", 
+            first_name_furigana=f"たろう{i+1}",
+            last_name_furigana="たなか",
+            birth_day=date(1990, 1, 1), 
+            gender=GenderType.male
+        )
         db_session.add(recipient)
         await db_session.flush()
         office_recipient = OfficeWelfareRecipient(welfare_recipient_id=recipient.id, office_id=office.id)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -35,12 +35,7 @@ async def engine() -> AsyncGenerator[AsyncEngine, None]:
     if "?sslmode" in DATABASE_URL:
         DATABASE_URL = DATABASE_URL.split("?")[0]
 
-    # execution_options を追加してバルクインサートを無効化
-    execution_options = {"insertmanyvalues_page_size": 1}
-    async_engine = create_async_engine(
-        DATABASE_URL,
-        execution_options=execution_options
-    )
+    async_engine = create_async_engine(DATABASE_URL)
     yield async_engine
     await async_engine.dispose()
 

--- a/tests/crud/test_crud_dashboard_summary.py
+++ b/tests/crud/test_crud_dashboard_summary.py
@@ -1,0 +1,300 @@
+# k_back/tests/crud/test_crud_dashboard_summary.py
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+from datetime import date, timedelta, datetime, timezone
+import uuid
+
+from app.crud.crud_dashboard import CRUDDashboard
+from app.models import (
+    Staff, Office, OfficeStaff, WelfareRecipient, OfficeWelfareRecipient,
+    SupportPlanCycle, SupportPlanStatus
+)
+from app.models.enums import (
+    StaffRole, OfficeType, GenderType, SupportPlanStep
+)
+
+# Pytestに非同期テストであることを認識させる
+pytestmark = pytest.mark.asyncio
+
+# テスト対象のCRUDインスタンス
+crud_dashboard = CRUDDashboard(WelfareRecipient)
+
+@pytest.fixture(scope="function")
+async def search_sort_filter_fixtures(db_session: AsyncSession, service_admin_user_factory, office_factory):
+    """検索・ソート・フィルター機能のテスト用フィクスチャ"""
+    # 1. スタッフと事業所の作成
+    staff = await service_admin_user_factory(email="summary_test@example.com")
+    office = await office_factory(creator=staff, name="サマリーテスト事業所")
+    db_session.add(OfficeStaff(staff_id=staff.id, office_id=office.id, is_primary=True))
+
+    # 2. 利用者データの定義
+    recipients_data = [
+        {"last_name": "佐藤", "first_name": "愛", "last_name_furigana": "さとう", "first_name_furigana": "あい", "created_at_delta": 30},
+        {"last_name": "鈴木", "first_name": "次郎", "last_name_furigana": "すずき", "first_name_furigana": "じろう", "created_at_delta": 20},
+        {"last_name": "高橋", "first_name": "学", "last_name_furigana": "たかはし", "first_name_furigana": "まなぶ", "created_at_delta": 5},
+        {"last_name": "田中", "first_name": "太郎", "last_name_furigana": "たなか", "first_name_furigana": "たろう", "created_at_delta": 10},
+        {"last_name": "伊藤", "first_name": "健太", "last_name_furigana": "いとう", "first_name_furigana": "けんた", "created_at_delta": 1},
+    ]
+    
+    recipients = []
+    for i, data in enumerate(recipients_data):
+        recipient = WelfareRecipient(
+            last_name=data["last_name"], first_name=data["first_name"],
+            last_name_furigana=data["last_name_furigana"], first_name_furigana=data["first_name_furigana"],
+            birth_day=date(1990, 1, 1), gender=GenderType.male,
+            created_at=datetime.now(timezone.utc) - timedelta(days=data["created_at_delta"])
+        )
+        db_session.add(recipient)
+
+        try:
+            await db_session.flush()
+        except Exception as e:
+            raise
+
+        db_session.add(OfficeWelfareRecipient(welfare_recipient_id=recipient.id, office_id=office.id))
+        recipients.append(recipient)
+
+    sato, suzuki, takahashi, tanaka, ito = recipients
+
+    # 3. 支援計画サイクルとステータスの作成
+    # 佐藤 愛 (期限切れ)
+    cycle_sato = SupportPlanCycle(welfare_recipient_id=sato.id, cycle_number=1, is_latest_cycle=True, next_renewal_deadline=date.today() - timedelta(days=10))
+    db_session.add(cycle_sato)
+    await db_session.flush()
+    db_session.add(SupportPlanStatus(plan_cycle_id=cycle_sato.id, step_type=SupportPlanStep.assessment, completed=False))
+
+    # 鈴木 次郎 (更新間近)
+    cycle_suzuki = SupportPlanCycle(welfare_recipient_id=suzuki.id, cycle_number=1, is_latest_cycle=True, next_renewal_deadline=date.today() + timedelta(days=15))
+    db_session.add(cycle_suzuki)
+    await db_session.flush()
+    db_session.add(SupportPlanStatus(plan_cycle_id=cycle_suzuki.id, step_type=SupportPlanStep.monitoring, completed=False))
+
+    # 高橋 学 (通常)
+    cycle_takahashi = SupportPlanCycle(welfare_recipient_id=takahashi.id, cycle_number=1, is_latest_cycle=True, next_renewal_deadline=date.today() + timedelta(days=90))
+    db_session.add(cycle_takahashi)
+    await db_session.flush()
+    db_session.add(SupportPlanStatus(plan_cycle_id=cycle_takahashi.id, step_type=SupportPlanStep.monitoring, completed=False))
+
+    # 田中 太郎 (通常)
+    cycle_tanaka_old = SupportPlanCycle(welfare_recipient_id=tanaka.id, cycle_number=1, is_latest_cycle=False)
+    cycle_tanaka_new = SupportPlanCycle(welfare_recipient_id=tanaka.id, cycle_number=2, is_latest_cycle=True, next_renewal_deadline=date.today() + timedelta(days=60))
+    db_session.add_all([cycle_tanaka_old, cycle_tanaka_new])
+    await db_session.flush()
+    db_session.add(SupportPlanStatus(plan_cycle_id=cycle_tanaka_new.id, step_type=SupportPlanStep.draft_plan, completed=False))
+
+    # 伊藤 健太 (サイクルなし)
+
+    await db_session.commit()
+    
+    return {"office_id": office.id, "recipients": {r.last_name: r for r in recipients}}
+
+
+class TestCRUDDashboardGetFilteredSummaries:
+    """crud.dashboard.get_filtered_summaries のテスト"""
+
+    async def test_no_filters_or_search(self, db_session: AsyncSession, search_sort_filter_fixtures):
+        """検索・フィルターなし: 全件がデフォルトソート順で返される"""
+        office_id = search_sort_filter_fixtures["office_id"]
+        
+        results = await crud_dashboard.get_filtered_summaries(
+            db=db_session, office_ids=[office_id],
+            sort_by="name_phonetic", sort_order="asc",
+            filters={}, search_term=None, skip=0, limit=10
+        )
+        
+        assert len(results) == 5
+        # デフォルトはフリガナ昇順
+        assert [r.last_name for r in results] == ["伊藤", "佐藤", "鈴木", "高橋", "田中"]
+
+    # --- 検索機能のテスト ---
+    async def test_search_by_last_name(self, db_session: AsyncSession, search_sort_filter_fixtures):
+        """検索: 姓での部分一致検索"""
+        office_id = search_sort_filter_fixtures["office_id"]
+        
+        results = await crud_dashboard.get_filtered_summaries(
+            db=db_session, office_ids=[office_id],
+            sort_by="name_phonetic", sort_order="asc",
+            filters={}, search_term="田", skip=0, limit=10
+        )
+        
+        assert len(results) == 1
+        assert results[0].last_name == "田中"
+
+    async def test_search_by_full_name(self, db_session: AsyncSession, search_sort_filter_fixtures):
+        """検索: フルネームでの検索"""
+        office_id = search_sort_filter_fixtures["office_id"]
+        
+        results = await crud_dashboard.get_filtered_summaries(
+            db=db_session, office_ids=[office_id],
+            sort_by="name_phonetic", sort_order="asc",
+            filters={}, search_term="鈴木 次郎", skip=0, limit=10
+        )
+        
+        assert len(results) == 1
+        assert results[0].last_name == "鈴木"
+
+    async def test_search_by_furigana(self, db_session: AsyncSession, search_sort_filter_fixtures):
+        """検索: フリガナでの検索"""
+        office_id = search_sort_filter_fixtures["office_id"]
+        
+        results = await crud_dashboard.get_filtered_summaries(
+            db=db_session, office_ids=[office_id],
+            sort_by="name_phonetic", sort_order="asc",
+            filters={}, search_term="さとう", skip=0, limit=10
+        )
+        
+        assert len(results) == 1
+        assert results[0].last_name == "佐藤"
+
+    async def test_search_no_results(self, db_session: AsyncSession, search_sort_filter_fixtures):
+        """検索: 該当なしの場合"""
+        office_id = search_sort_filter_fixtures["office_id"]
+        
+        results = await crud_dashboard.get_filtered_summaries(
+            db=db_session, office_ids=[office_id],
+            sort_by="name_phonetic", sort_order="asc",
+            filters={}, search_term="山田", skip=0, limit=10
+        )
+        
+        assert len(results) == 0
+
+    # --- ソート機能のテスト ---
+    async def test_sort_by_created_at_desc(self, db_session: AsyncSession, search_sort_filter_fixtures):
+        """ソート: 作成日時の降順"""
+        office_id = search_sort_filter_fixtures["office_id"]
+        
+        results = await crud_dashboard.get_filtered_summaries(
+            db=db_session, office_ids=[office_id],
+            sort_by="created_at", sort_order="desc",
+            filters={}, search_term=None, skip=0, limit=10
+        )
+        
+        assert len(results) == 5
+        assert [r.last_name for r in results] == ["伊藤", "高橋", "田中", "鈴木", "佐藤"]
+
+    async def test_sort_by_next_renewal_deadline_asc(self, db_session: AsyncSession, search_sort_filter_fixtures):
+        """ソート: 次回更新日の昇順（サイクルがない利用者は含まれない）"""
+        office_id = search_sort_filter_fixtures["office_id"]
+        
+        results = await crud_dashboard.get_filtered_summaries(
+            db=db_session, office_ids=[office_id],
+            sort_by="next_renewal_deadline", sort_order="asc",
+            filters={}, search_term=None, skip=0, limit=10
+        )
+        
+        # サイクルを持つ4人のみ
+        assert len(results) == 4
+        assert [r.last_name for r in results] == ["佐藤", "鈴木", "田中", "高橋"]
+
+    # --- フィルター機能のテスト ---
+    async def test_filter_is_overdue(self, db_session: AsyncSession, search_sort_filter_fixtures):
+        """フィルター: 期限切れ"""
+        office_id = search_sort_filter_fixtures["office_id"]
+        
+        results = await crud_dashboard.get_filtered_summaries(
+            db=db_session, office_ids=[office_id],
+            sort_by="name_phonetic", sort_order="asc",
+            filters={"is_overdue": True}, search_term=None, skip=0, limit=10
+        )
+        
+        assert len(results) == 1
+        assert results[0].last_name == "佐藤"
+
+    async def test_filter_is_upcoming(self, db_session: AsyncSession, search_sort_filter_fixtures):
+        """フィルター: 更新間近"""
+        office_id = search_sort_filter_fixtures["office_id"]
+        
+        results = await crud_dashboard.get_filtered_summaries(
+            db=db_session, office_ids=[office_id],
+            sort_by="name_phonetic", sort_order="asc",
+            filters={"is_upcoming": True}, search_term=None, skip=0, limit=10
+        )
+        
+        assert len(results) == 1
+        assert results[0].last_name == "鈴木"
+
+    async def test_filter_by_status(self, db_session: AsyncSession, search_sort_filter_fixtures):
+        """フィルター: ステータス"""
+        office_id = search_sort_filter_fixtures["office_id"]
+        
+        results = await crud_dashboard.get_filtered_summaries(
+            db=db_session, office_ids=[office_id],
+            sort_by="name_phonetic", sort_order="asc",
+            filters={"status": SupportPlanStep.draft_plan}, search_term=None, skip=0, limit=10
+        )
+        
+        assert len(results) == 1
+        assert results[0].last_name == "田中"
+
+    async def test_filter_by_cycle_number(self, db_session: AsyncSession, search_sort_filter_fixtures):
+        """フィルター: サイクル番号"""
+        office_id = search_sort_filter_fixtures["office_id"]
+        
+        results = await crud_dashboard.get_filtered_summaries(
+            db=db_session, office_ids=[office_id],
+            sort_by="name_phonetic", sort_order="asc",
+            filters={"cycle_number": 2}, search_term=None, skip=0, limit=10
+        )
+        
+        assert len(results) == 1
+        assert results[0].last_name == "田中"
+
+    # --- 複合条件のテスト ---
+    async def test_search_with_overdue_filter(self, db_session: AsyncSession, search_sort_filter_fixtures):
+        """複合: 検索 + 期限切れフィルター"""
+        office_id = search_sort_filter_fixtures["office_id"]
+        
+        results = await crud_dashboard.get_filtered_summaries(
+            db=db_session,
+            office_ids=[office_id],
+            sort_by="name_phonetic",
+            sort_order="asc",
+            filters={"is_overdue": True},
+            search_term="佐藤",
+            skip=0,
+            limit=50
+        )
+        assert len(results) == 1
+        assert results[0].last_name == "佐藤"
+
+    async def test_contradictory_filters(self, db_session: AsyncSession, search_sort_filter_fixtures):
+        """複合: 矛盾するフィルター条件 (期限切れ AND 更新間近)"""
+        office_id = search_sort_filter_fixtures["office_id"]
+        
+        results = await crud_dashboard.get_filtered_summaries(
+            db=db_session,
+            office_ids=[office_id],
+            sort_by="name_phonetic",
+            sort_order="asc",
+            filters={
+                "is_overdue": True,
+                "is_upcoming": True
+            },
+            search_term=None,
+            skip=0,
+            limit=50
+        )
+        # 矛盾する条件なので結果は0件になる
+        assert len(results) == 0
+
+    async def test_all_conditions_combined(self, db_session: AsyncSession, search_sort_filter_fixtures):
+        """複合: 全条件の組み合わせ"""
+        office_id = search_sort_filter_fixtures["office_id"]
+        
+        results = await crud_dashboard.get_filtered_summaries(
+            db=db_session,
+            office_ids=[office_id],
+            sort_by="next_renewal_deadline",
+            sort_order="asc",
+            filters={
+                "is_upcoming": True,
+                "status": SupportPlanStep.monitoring,
+                "cycle_number": 1
+            },
+            search_term="すずき",
+            skip=0,
+            limit=50
+        )
+        assert len(results) == 1
+        assert results[0].last_name == "鈴木"

--- a/tests/schemas/test_dashboard_schema.py
+++ b/tests/schemas/test_dashboard_schema.py
@@ -7,7 +7,7 @@ import uuid
 
 from app.schemas.dashboard import (
     DashboardData,
-    DashboardRecipient,
+    DashboardSummary,
     DashboardBase,
     DashboardDataCreate
 )
@@ -17,11 +17,11 @@ from app.models.enums import StaffRole, BillingStatus, SupportPlanStep
 pytestmark = pytest.mark.asyncio
 
 
-class TestDashboardRecipientSchema:
-    """DashboardRecipientスキーマのテスト"""
+class TestDashboardSummarySchema:
+    """DashboardSummaryスキーマのテスト"""
     
     def test_dashboard_recipient_valid_data(self):
-        """正常系: 有効なデータでDashboardRecipientが作成される"""
+        """正常系: 有効なデータでDashboardSummaryが作成される"""
         valid_data = {
             "id": str(uuid.uuid4()),
             "full_name": "田中 太郎",
@@ -33,7 +33,7 @@ class TestDashboardRecipientSchema:
         }
         
         # テスト実行
-        recipient = DashboardRecipient(**valid_data)
+        recipient = DashboardSummary(**valid_data)
         
         # 検証
         assert recipient.id == valid_data["id"]
@@ -45,7 +45,7 @@ class TestDashboardRecipientSchema:
         assert recipient.monitoring_due_date == date(2024, 2, 28)
     
     def test_dashboard_recipient_minimal_data(self):
-        """正常系: 必須フィールドのみでDashboardRecipientが作成される"""
+        """正常系: 必須フィールドのみでDashboardSummaryが作成される"""
         minimal_data = {
             "id": str(uuid.uuid4()),
             "full_name": "山田 花子",
@@ -57,7 +57,7 @@ class TestDashboardRecipientSchema:
         }
         
         # テスト実行
-        recipient = DashboardRecipient(**minimal_data)
+        recipient = DashboardSummary(**minimal_data)
         
         # 検証
         assert str(recipient.id) == minimal_data["id"]
@@ -82,7 +82,7 @@ class TestDashboardRecipientSchema:
         
         # テスト実行・検証
         with pytest.raises(ValidationError) as exc_info:
-            DashboardRecipient(**invalid_data)
+            DashboardSummary(**invalid_data)
         
         # エラー詳細確認
         errors = exc_info.value.errors()
@@ -102,7 +102,7 @@ class TestDashboardRecipientSchema:
         
         # テスト実行・検証
         with pytest.raises(ValidationError) as exc_info:
-            DashboardRecipient(**invalid_data)
+            DashboardSummary(**invalid_data)
         
         # エラー詳細確認
         errors = exc_info.value.errors()
@@ -122,7 +122,7 @@ class TestDashboardRecipientSchema:
         
         # テスト実行・検証
         with pytest.raises(ValidationError) as exc_info:
-            DashboardRecipient(**invalid_data)
+            DashboardSummary(**invalid_data)
         
         # エラー詳細確認
         errors = exc_info.value.errors()
@@ -142,7 +142,7 @@ class TestDashboardRecipientSchema:
         
         # テスト実行・検証
         with pytest.raises(ValidationError) as exc_info:
-            DashboardRecipient(**invalid_data)
+            DashboardSummary(**invalid_data)
         
         # エラー詳細確認
         errors = exc_info.value.errors()
@@ -162,7 +162,7 @@ class TestDashboardRecipientSchema:
         
         # テスト実行・検証
         with pytest.raises(ValidationError) as exc_info:
-            DashboardRecipient(**invalid_data)
+            DashboardSummary(**invalid_data)
         
         # エラー詳細確認
         errors = exc_info.value.errors()
@@ -218,7 +218,7 @@ class TestDashboardDataSchema:
         assert dashboard.max_user_count == 10
         assert dashboard.billing_status == BillingStatus.free
         assert len(dashboard.recipients) == 2
-        assert isinstance(dashboard.recipients[0], DashboardRecipient)
+        assert isinstance(dashboard.recipients[0], DashboardSummary)
     
     def test_dashboard_data_empty_recipients(self):
         """正常系: 利用者が0人のDashboardData"""
@@ -387,7 +387,7 @@ class TestDashboardSchemaEdgeCases:
         }
         
         # テスト実行
-        recipient = DashboardRecipient(**valid_data)
+        recipient = DashboardSummary(**valid_data)
         
         # 検証: 長い名前も受け入れられる
         assert recipient.full_name == long_name
@@ -426,7 +426,7 @@ class TestDashboardSchemaEdgeCases:
         # 検証
         assert len(dashboard.recipients) == 1000
         assert dashboard.current_user_count == 1000
-        assert all(isinstance(recipient, DashboardRecipient) for recipient in dashboard.recipients)
+        assert all(isinstance(recipient, DashboardSummary) for recipient in dashboard.recipients)
     
     def test_dashboard_recipient_special_characters(self):
         """エッジケース: 特殊文字を含む名前"""
@@ -441,7 +441,7 @@ class TestDashboardSchemaEdgeCases:
         }
         
         # テスト実行
-        recipient = DashboardRecipient(**special_data)
+        recipient = DashboardSummary(**special_data)
         
         # 検証: 特殊文字も受け入れられる
         assert recipient.full_name == "田中♪ 太郎★"
@@ -483,7 +483,7 @@ class TestDashboardSchemaEdgeCases:
         }
         
         # テスト実行
-        recipient = DashboardRecipient(**boundary_data)
+        recipient = DashboardSummary(**boundary_data)
         
         # 検証: 境界値の日付も正しく処理される
         assert recipient.next_renewal_deadline == far_future
@@ -505,7 +505,7 @@ class TestDashboardSchemaValidation:
         
         # テスト実行・検証
         with pytest.raises(ValidationError) as exc_info:
-            DashboardRecipient(**incomplete_data)
+            DashboardSummary(**incomplete_data)
         
         # エラー詳細確認
         errors = exc_info.value.errors()
@@ -546,7 +546,7 @@ class TestDashboardSchemaValidation:
         }
         
         # テスト実行
-        recipient = DashboardRecipient(**data_with_extra)
+        recipient = DashboardSummary(**data_with_extra)
         
         # 検証: 余分なフィールドは無視され、正常に作成される
         assert recipient.full_name == "テスト 太郎"


### PR DESCRIPTION
## 📋 ダッシュボード検索・ソート・フィルター機能の実装

### 🎯 概要
ダッシュボードページにて、利用者一覧に対する検索・ソート・フィルター機能を実装し、職員が効率的に担当利用者の状況を把握できるようにする。

### 📝 要件詳細

#### 🔍 検索機能
- **全文検索対応**: 一つの検索欄で名前（漢字）・フリガナを横断検索
- **複数キーワード対応**: スペース区切りで複数キーワードをAND検索
- **柔軟な検索**: 姓名の順序を問わない検索（「田中 太郎」「太郎 田中」両方で検索可能）
- **部分一致**: 「田」で「田中」がヒット
- **リアルタイム検索**: 入力中にリアルタイムで結果を更新（300ms デバウンス）

#### 📊 ソート機能
1. **次回更新日順**: `next_renewal_deadline` の昇順・降順
2. **作成日順**: 利用者の作成日時の昇順・降順
3. **関連度順**: 検索実行時のみ、検索語との一致度順

#### 🗂️ フィルター機能
1. **期限切れ**: 更新期限が過ぎている利用者のみ表示
2. **更新間近**: 30日以内に更新期限が来る利用者のみ表示
3. **ステータス別**: 特定の支援計画ステップ（アセスメント、モニタリング等）でフィルタリング

#### 〠エンドポイント
例:
api/v1/dashboard/?sort_by=next_renewal_deadline&sort_order=asc