### PR TITLE
fix: test plan_cycle_start_date, nullable=falseと修正

### DIFF
--- a/tests/crud/test_crud_dashboard_summary.py
+++ b/tests/crud/test_crud_dashboard_summary.py
@@ -59,26 +59,27 @@ async def search_sort_filter_fixtures(db_session: AsyncSession, service_admin_us
 
     # 3. 支援計画サイクルとステータスの作成
     # 佐藤 愛 (期限切れ)
-    cycle_sato = SupportPlanCycle(welfare_recipient_id=sato.id, cycle_number=1, is_latest_cycle=True, next_renewal_deadline=date.today() - timedelta(days=10))
+    cycle_sato = SupportPlanCycle(welfare_recipient_id=sato.id, plan_cycle_start_date=date.today() - timedelta(days=375), cycle_number=1, is_latest_cycle=True, next_renewal_deadline=date.today() - timedelta(days=10))
     db_session.add(cycle_sato)
     await db_session.flush()
     db_session.add(SupportPlanStatus(plan_cycle_id=cycle_sato.id, step_type=SupportPlanStep.assessment, completed=False))
 
     # 鈴木 次郎 (更新間近)
-    cycle_suzuki = SupportPlanCycle(welfare_recipient_id=suzuki.id, cycle_number=1, is_latest_cycle=True, next_renewal_deadline=date.today() + timedelta(days=15))
+    cycle_suzuki = SupportPlanCycle(welfare_recipient_id=suzuki.id, plan_cycle_start_date=date.today() - timedelta(days=350), cycle_number=1, is_latest_cycle=True, next_renewal_deadline=date.today() + timedelta(days=15))
     db_session.add(cycle_suzuki)
     await db_session.flush()
     db_session.add(SupportPlanStatus(plan_cycle_id=cycle_suzuki.id, step_type=SupportPlanStep.monitoring, completed=False))
 
     # 高橋 学 (通常)
-    cycle_takahashi = SupportPlanCycle(welfare_recipient_id=takahashi.id, cycle_number=1, is_latest_cycle=True, next_renewal_deadline=date.today() + timedelta(days=90))
+    cycle_takahashi = SupportPlanCycle(welfare_recipient_id=takahashi.id, plan_cycle_start_date=date.today() - timedelta(days=275), cycle_number=1, is_latest_cycle=True, next_renewal_deadline=date.today() + timedelta(days=90))
     db_session.add(cycle_takahashi)
     await db_session.flush()
     db_session.add(SupportPlanStatus(plan_cycle_id=cycle_takahashi.id, step_type=SupportPlanStep.monitoring, completed=False))
 
     # 田中 太郎 (通常)
-    cycle_tanaka_old = SupportPlanCycle(welfare_recipient_id=tanaka.id, cycle_number=1, is_latest_cycle=False)
-    cycle_tanaka_new = SupportPlanCycle(welfare_recipient_id=tanaka.id, cycle_number=2, is_latest_cycle=True, next_renewal_deadline=date.today() + timedelta(days=60))
+    new_plan_start_date = date.today() - timedelta(days=305)
+    cycle_tanaka_old = SupportPlanCycle(welfare_recipient_id=tanaka.id, plan_cycle_start_date=new_plan_start_date - timedelta(days=365), cycle_number=1, is_latest_cycle=False)
+    cycle_tanaka_new = SupportPlanCycle(welfare_recipient_id=tanaka.id, plan_cycle_start_date=new_plan_start_date, cycle_number=2, is_latest_cycle=True, next_renewal_deadline=date.today() + timedelta(days=60))
     db_session.add_all([cycle_tanaka_old, cycle_tanaka_new])
     await db_session.flush()
     db_session.add(SupportPlanStatus(plan_cycle_id=cycle_tanaka_new.id, step_type=SupportPlanStep.draft_plan, completed=False))


### PR DESCRIPTION
```py
    async def execute(
        self,
        query: Query,
        params: Params | None = None,
        *,
        prepare: bool | None = None,
        binary: bool | None = None,
    ) -> Self:
        """
        Execute a query or command to the database.
        """
        try:
            async with self._conn.lock:
                await self._conn.wait(
                    self._execute_gen(query, params, prepare=prepare, binary=binary)
                )
        except e._NO_TRACEBACK as ex:
>           raise ex.with_traceback(None)
E           sqlalchemy.exc.IntegrityError: (psycopg.errors.NotNullViolation) null value in column "plan_cycle_start_date" of relation "support_plan_cycles" violates not-null constraint
E           DETAIL:  Failing row contains (104, 409bd522-437a-400c-a818-3d74c5021055, null, null, 2025-09-09, t, null, null, null, 2025-09-19 05:49:05.591846+00, 2025-09-19 05:49:05.591846+00, 1).
E           [SQL: INSERT INTO support_plan_cycles (welfare_recipient_id, plan_cycle_start_date, final_plan_signed_date, next_renewal_deadline, is_latest_cycle, cycle_number, google_calendar_id, google_event_id, google_event_url) VALUES (%(welfare_recipient_id)s::UUID, %(plan_cycle_start_date)s::DATE, %(final_plan_signed_date)s::DATE, %(next_renewal_deadline)s::DATE, %(is_latest_cycle)s, %(cycle_number)s::INTEGER, %(google_calendar_id)s::VARCHAR, %(google_event_id)s::VARCHAR, %(google_event_url)s::VARCHAR) RETURNING support_plan_cycles.id, support_plan_cycles.created_at, support_plan_cycles.updated_at]
E           [parameters: ***'welfare_recipient_id': UUID('409bd522-437a-400c-a818-3d74c5021055'), 'plan_cycle_start_date': None, 'final_plan_signed_date': None, 'next_renewal_deadline': datetime.date(2025, 9, 9), 'is_latest_cycle': True, 'cycle_number': 1, 'google_calendar_id': None, 'google_event_id': None, 'google_event_url': None***]
E           (Background on this error at: https://sqlalche.me/e/20/gkpj)
```

本番環境のpytestで上記のエラー
DB上でsupport_plan_cycle: plan_cycle_start_date, nullable=trueになっていたため発生した
そのためテストをnullable=falseとして修正した