### PR TITLE
fix: Vercel Preview CORS + E2Eテスト基盤

### DIFF
--- a/app/api/v1/api.py
+++ b/app/api/v1/api.py
@@ -27,6 +27,7 @@ from app.api.v1.endpoints import (
     inquiries,
     billing,
     push_subscriptions,
+    e2e_cleanup,
 )
 
 api_router = APIRouter()
@@ -58,3 +59,4 @@ api_router.include_router(archived_staffs.router, prefix="/admin/archived-staffs
 api_router.include_router(inquiries.router, prefix="/inquiries", tags=["inquiries"])
 api_router.include_router(billing.router, prefix="/billing", tags=["billing"])
 api_router.include_router(push_subscriptions.router, prefix="/push-subscriptions", tags=["push-subscriptions"])
+api_router.include_router(e2e_cleanup.router, prefix="/e2e", tags=["e2e-cleanup"])

--- a/app/api/v1/endpoints/billing.py
+++ b/app/api/v1/endpoints/billing.py
@@ -4,6 +4,7 @@ Billing API エンドポイント (Phase 2)
 from typing import Annotated
 from datetime import datetime, timezone
 from uuid import UUID
+import json
 from fastapi import APIRouter, Depends, HTTPException, status, Request, Header
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.exc import IntegrityError
@@ -295,7 +296,9 @@ async def stripe_webhook(
     # リクエストボディを取得
     payload = await request.body()
 
-    # Stripe署名を検証
+    # Stripe署名を検証し、イベントオブジェクトを取得する
+    # stripe-python v5+ の StripeObject は .get() を持たないため、
+    # dict に変換してからサービス層に渡すことで後方互換性を維持する。
     try:
         event = stripe.Webhook.construct_event(
             payload,
@@ -309,10 +312,16 @@ async def stripe_webhook(
         logger.error("Invalid signature")
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=ja.BILLING_WEBHOOK_INVALID_SIGNATURE)
 
-    # イベントタイプによって処理を分岐
-    event_type = event['type']
-    event_data = event['data']['object']
-    event_id = event.get('id', 'unknown')
+    # 署名検証済みのイベントを plain dict として取得する
+    #
+    # 変換方針:
+    #   - テスト環境: @patch により construct_event が plain dict を返す → そのまま使用
+    #   - 本番環境: stripe.Event オブジェクトが返る → json.loads(payload) で変換
+    #     (署名検証済みのペイロードを再度解析するため安全)
+    event_dict: dict = event if isinstance(event, dict) else json.loads(payload)
+    event_type: str = event_dict['type']
+    event_data: dict = event_dict['data']['object']
+    event_id: str = event_dict.get('id', 'unknown')
 
     # 【Phase 7】冪等性チェック: 既に処理済みのイベントはスキップ
     is_processed = await crud.webhook_event.is_event_processed(db=db, event_id=event_id)

--- a/app/api/v1/endpoints/e2e_cleanup.py
+++ b/app/api/v1/endpoints/e2e_cleanup.py
@@ -1,0 +1,59 @@
+"""
+E2Eテスト専用クリーンアップエンドポイント
+
+ENVIRONMENT が 'production' の場合は 403 を返し、一切の操作を行わない。
+開発・テスト環境でのみ使用可能。
+"""
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy import select
+from datetime import datetime, timezone
+
+from app.api import deps
+from app.models.staff import Staff
+from app.models.enums import StaffRole
+from app.core.config import settings
+
+router = APIRouter()
+
+
+@router.delete("/staffs", status_code=status.HTTP_200_OK)
+async def cleanup_e2e_staffs(
+    db: AsyncSession = Depends(deps.get_db),
+    current_user: Staff = Depends(deps.require_owner),
+) -> dict:
+    """
+    E2Eテスト用スタッフを一括削除する（非本番環境・owner のみ）
+
+    対象: email が 'e2e_staff_' で始まるスタッフ
+    処理: 論理削除（is_deleted=True, deleted_at=now）
+    制限: ENVIRONMENT=production または owner 以外は 403 を返す
+    """
+    if settings.ENVIRONMENT == "production":
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="本番環境ではこの操作は使用できません",
+        )
+
+    # e2e_staff_ で始まる未削除スタッフを取得
+    result = await db.execute(
+        select(Staff).where(
+            Staff.email.like("e2e_staff_%"),
+            Staff.is_deleted == False,  # noqa: E712
+        )
+    )
+    staffs = result.scalars().all()
+
+    if not staffs:
+        return {"deleted_count": 0, "deleted_emails": []}
+
+    now = datetime.now(timezone.utc)
+    deleted_emails = []
+    for staff in staffs:
+        staff.is_deleted = True
+        staff.deleted_at = now
+        deleted_emails.append(staff.email)
+
+    await db.commit()
+
+    return {"deleted_count": len(deleted_emails), "deleted_emails": deleted_emails}

--- a/app/api/v1/endpoints/staffs.py
+++ b/app/api/v1/endpoints/staffs.py
@@ -292,8 +292,11 @@ async def delete_staff(
             )
 
         # 同一事務所チェック
+        # 事業所未所属（メール未確認・未承認状態）のスタッフは事務所チェックをスキップする。
+        # 未所属スタッフはいかなる事業所のデータにもアクセスできないため、
+        # どの事業所の owner も削除可能とする（E2Eテスト後クリーンアップを含む）。
         target_staff_office_ids = {assoc.office_id for assoc in target_staff.office_associations}
-        if current_user_office.id not in target_staff_office_ids:
+        if target_staff_office_ids and current_user_office.id not in target_staff_office_ids:
             raise HTTPException(
                 status_code=status.HTTP_403_FORBIDDEN,
                 detail=ja.STAFF_DIFFERENT_OFFICE

--- a/app/main.py
+++ b/app/main.py
@@ -175,9 +175,12 @@ else:
     ]
 
 # CORSミドルウェアの設定
+# allow_origin_regex: Vercel Preview デプロイの動的 URL（keikakun-front-*.vercel.app）を許可する。
+# allow_credentials=True 時は allow_origins=["*"] が使えないため正規表現で対応する。
 app.add_middleware(
     CORSMiddleware,
     allow_origins=allowed_origins,
+    allow_origin_regex=r"https://keikakun-front[^.]*\.vercel\.app",
     allow_credentials=True,  # Cookie送信のために必要
     allow_methods=allowed_methods,
     allow_headers=allowed_headers,

--- a/scripts/create_e2e_owner.py
+++ b/scripts/create_e2e_owner.py
@@ -125,13 +125,18 @@ async def create_e2e_owner(email: str, password: str) -> bool:
 
 
 if __name__ == "__main__":
-    if len(sys.argv) != 3:
-        print("使用方法: python scripts/create_e2e_owner.py <email> <password>")
-        print("例:       python scripts/create_e2e_owner.py e2e_owner@example.com 'E2ePass123!'")
-        sys.exit(1)
+    # CLI 引数優先、なければ環境変数から取得（CI での秘密情報漏洩防止）
+    if len(sys.argv) == 3:
+        email = sys.argv[1]
+        password = sys.argv[2]
+    else:
+        email = os.environ.get("E2E_OWNER_EMAIL", "")
+        password = os.environ.get("E2E_OWNER_PASSWORD", "")
 
-    email = sys.argv[1]
-    password = sys.argv[2]
+    if not email or not password:
+        print("使用方法 (引数): python scripts/create_e2e_owner.py <email> <password>")
+        print("使用方法 (env):  E2E_OWNER_EMAIL=... E2E_OWNER_PASSWORD=... python scripts/create_e2e_owner.py")
+        sys.exit(1)
 
     success = asyncio.run(create_e2e_owner(email, password))
     sys.exit(0 if success else 1)

--- a/scripts/create_e2e_owner.py
+++ b/scripts/create_e2e_owner.py
@@ -1,0 +1,137 @@
+"""
+E2Eテスト用 owner スタッフアカウントを作成するスクリプト
+
+GitHub Actions の E2E テストで使用するテスト専用 owner アカウント（事業所付き）を生成する。
+作成後、GitHub Actions Secrets に E2E_OWNER_EMAIL / E2E_OWNER_PASSWORD として登録する。
+
+使用方法:
+  docker compose exec backend python scripts/create_e2e_owner.py <email> <password>
+
+例:
+  docker compose exec backend python scripts/create_e2e_owner.py e2e_owner@example.com "E2ePass123!"
+
+引数:
+  - email:    メールアドレス（GitHub Actions Secret の E2E_OWNER_EMAIL に使用）
+  - password: パスワード（GitHub Actions Secret の E2E_OWNER_PASSWORD に使用）
+
+作成されるデータ:
+  - staffs テーブル:      owner ロールのスタッフ（MFA無効・メール認証済み）
+  - offices テーブル:     E2Eテスト用事業所
+  - office_staffs テーブル: スタッフと事業所の紐付け
+  - billings テーブル:    active ステータスの課金レコード（操作制限なし）
+
+注意:
+  - is_test_data=True でマーク → テストDBクリーンアップ対象にならないよう運用で管理
+  - MFA は無効化（is_mfa_enabled=False）← ログインをシンプルにするため
+  - 本番DBには実行しないこと（dev/staging のみ）
+"""
+import asyncio
+import sys
+import os
+from datetime import datetime, timezone, timedelta
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from sqlalchemy import select
+from app.db.session import async_session_maker
+from app.models.staff import Staff
+from app.models.office import Office, OfficeStaff
+from app.models.billing import Billing
+from app.models.enums import StaffRole, OfficeType, BillingStatus
+from app.core.security import get_password_hash
+
+
+async def create_e2e_owner(email: str, password: str) -> bool:
+    """
+    E2Eテスト用 owner アカウントを作成する
+
+    Args:
+        email:    メールアドレス
+        password: パスワード（平文）
+
+    Returns:
+        成功した場合は True
+    """
+    async with async_session_maker() as db:
+        # --- 重複チェック ---
+        existing = await db.execute(select(Staff).where(Staff.email == email))
+        if existing.scalar_one_or_none():
+            print(f"[skip] Staff with email '{email}' already exists.")
+            print("       既存アカウントをそのまま GitHub Actions Secret に登録してください。")
+            return True
+
+        # --- 1. Staff（owner）を作成 ---
+        staff = Staff(
+            email=email,
+            hashed_password=get_password_hash(password),
+            role=StaffRole.owner,
+            first_name="テスト",
+            last_name="E2E",
+            full_name="E2E テスト",
+            is_email_verified=True,   # メール認証をスキップ
+            is_mfa_enabled=False,     # MFAを無効化（E2Eログインを簡素化）
+            password_changed_at=datetime.now(timezone.utc),
+            is_test_data=False,       # 通常のクリーンアップ対象外
+        )
+        db.add(staff)
+        await db.flush()  # staff.id を確定させる
+
+        # --- 2. Office（事業所）を作成 ---
+        office = Office(
+            name="E2Eテスト事業所",
+            type=OfficeType.transition_to_employment,
+            created_by=staff.id,
+            last_modified_by=staff.id,
+            is_test_data=False,
+        )
+        db.add(office)
+        await db.flush()  # office.id を確定させる
+
+        # --- 3. OfficeStaff（スタッフ↔事業所の紐付け）---
+        office_staff = OfficeStaff(
+            staff_id=staff.id,
+            office_id=office.id,
+            is_primary=True,
+            is_test_data=False,
+        )
+        db.add(office_staff)
+
+        # --- 4. Billing（active ステータス）---
+        now = datetime.now(timezone.utc)
+        billing = Billing(
+            office_id=office.id,
+            billing_status=BillingStatus.active,
+            trial_start_date=now,
+            trial_end_date=now + timedelta(days=180),
+            subscription_start_date=now,
+        )
+        db.add(billing)
+
+        await db.commit()
+
+        print("=" * 50)
+        print("✅ E2Eテスト用 owner アカウントを作成しました")
+        print("=" * 50)
+        print(f"  Email   : {email}")
+        print(f"  Password: {password}")
+        print(f"  Staff ID: {staff.id}")
+        print(f"  Office  : E2Eテスト事業所 (id={office.id})")
+        print(f"  Billing : {BillingStatus.active.value}")
+        print()
+        print("GitHub Actions Secrets に以下を登録してください:")
+        print(f"  E2E_OWNER_EMAIL    = {email}")
+        print(f"  E2E_OWNER_PASSWORD = {password}")
+        return True
+
+
+if __name__ == "__main__":
+    if len(sys.argv) != 3:
+        print("使用方法: python scripts/create_e2e_owner.py <email> <password>")
+        print("例:       python scripts/create_e2e_owner.py e2e_owner@example.com 'E2ePass123!'")
+        sys.exit(1)
+
+    email = sys.argv[1]
+    password = sys.argv[2]
+
+    success = asyncio.run(create_e2e_owner(email, password))
+    sys.exit(0 if success else 1)


### PR DESCRIPTION
## Summary

- **CORS修正**: `allow_origin_regex` で `keikakun-front-*.vercel.app` を許可（Vercel Preview デプロイからのリクエストがブロックされていた問題を解消）
- **E2Eクリーンアップ**: E2Eテスト用クリーンアップエンドポイント追加・スタッフ削除改善
- **Stripe v14対応**: Webhook StripeObject の `.get()` 廃止を修正
- **ownerアカウントスクリプト**: E2Eテスト用 owner アカウント作成スクリプト追加

## Test plan

- [ ] `POST /api/v1/auth/token` に Vercel Preview URL（`https://keikakun-front-*.vercel.app`）からのプリフライトが 200 を返すことを確認
- [ ] 本番ドメイン（`https://keikakun-front.vercel.app`, `https://www.keikakun.com`）への CORS が引き続き動作することを確認
- [ ] k_front PR #55 の E2E CI が pass することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)