### PR TITLE
fix: refine billing status transitions

### DIFF
--- a/app/api/deps.py
+++ b/app/api/deps.py
@@ -45,22 +45,16 @@ async def get_current_user(
     1. Cookie (access_token)
     2. Authorization ヘッダー (Bearer token)
     """
-    print("\n" + "="*80)
-    print("=== get_current_user called ===")
-
     # まずCookieからトークンを取得
     cookie_token = request.cookies.get("access_token")
 
     # Cookieが優先、なければAuthorizationヘッダーから
     final_token = cookie_token if cookie_token else token
 
-    print(f"Cookie token: {cookie_token[:20]}..." if cookie_token else "No cookie token")
-    print(f"Header token: {token[:20]}..." if token else "No header token")
-    print(f"Using token: {final_token[:20]}..." if final_token else "No token")
-    logger.info("=== get_current_user called ===")
-    logger.info(f"Cookie token: {'present' if cookie_token else 'absent'}")
-    logger.info(f"Header token: {'present' if token else 'absent'}")
-    logger.info(f"Using token from: {'cookie' if cookie_token else 'header' if token else 'none'}")
+    logger.debug("get_current_user called")
+    logger.debug("Cookie token: %s", "present" if cookie_token else "absent")
+    logger.debug("Header token: %s", "present" if token else "absent")
+    logger.debug("Using token from: %s", "cookie" if cookie_token else "header" if token else "none")
 
     credentials_exception = HTTPException(
         status_code=status.HTTP_401_UNAUTHORIZED,
@@ -69,41 +63,33 @@ async def get_current_user(
     )
 
     if not final_token:
-        print("No token provided - raising 401")
         logger.warning("No token provided - raising 401")
         raise credentials_exception
 
     payload = decode_access_token(final_token)
-    print(f"Decoded payload: {payload}")
-    logger.info(f"Decoded payload: {payload}")
+    logger.debug("Decoded token payload")
 
     if payload is None:
-        print("Payload is None - raising 401")
         logger.warning("Payload is None - raising 401")
         raise credentials_exception
 
     try:
         token_data = TokenData(sub=payload.get("sub"))
-        print(f"TokenData created with sub: {token_data.sub}")
-        logger.info(f"TokenData created with sub: {token_data.sub}")
+        logger.debug("TokenData created with sub=%s", token_data.sub)
     except ValidationError as e:
-        print(f"ValidationError: {e}")
-        logger.warning(f"ValidationError: {e}")
+        logger.warning("TokenData validation error: %s", e)
         raise credentials_exception
 
     if token_data.sub is None:
-        print("token_data.sub is None - raising 401")
         logger.warning("token_data.sub is None - raising 401")
         raise credentials_exception
 
     # IDを元に、crud層を経由してユーザーをデータベースから検索します。
     try:
         user_id = uuid.UUID(token_data.sub)
-        print(f"Parsed user_id: {user_id}")
-        logger.info(f"Parsed user_id: {user_id}")
+        logger.debug("Parsed user_id=%s", user_id)
     except ValueError as e:
-        print(f"ValueError parsing UUID: {e}")
-        logger.warning(f"ValueError parsing UUID: {e}")
+        logger.warning("ValueError parsing UUID: %s", e)
         raise credentials_exception
 
     from sqlalchemy.orm import selectinload
@@ -117,8 +103,7 @@ async def get_current_user(
     user = result.scalars().first()
 
     if not user:
-        print(f"User not found for id: {user_id}")
-        logger.warning(f"User not found for id: {user_id}")
+        logger.warning("User not found for id: %s", user_id)
         raise credentials_exception
 
     # app_admin以外の場合、所属事務所の削除済みチェック（スタッフチェックより先に実行）
@@ -128,7 +113,6 @@ async def get_current_user(
             # いずれかの事務所が削除済みの場合、アクセス拒否
             for office_assoc in user.office_associations:
                 if office_assoc.office and office_assoc.office.is_deleted:
-                    print(f"User's office is deleted: office_id={office_assoc.office.id}")
                     logger.warning(f"User {user.email} attempted access with deleted office: office_id={office_assoc.office.id}")
                     raise HTTPException(
                         status_code=status.HTTP_403_FORBIDDEN,
@@ -138,7 +122,6 @@ async def get_current_user(
 
     # 削除済みスタッフチェック（事務所チェックの後に実行）
     if user.is_deleted:
-        print(f"User is deleted: {user.email}")
         logger.warning(f"Deleted user attempted access: {user.email}")
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN,
@@ -158,9 +141,6 @@ async def get_current_user(
 
             # パスワード変更時刻とトークン発行時刻を比較
             if user.password_changed_at > token_issued_at:
-                print(f"Token issued before password change - rejecting")
-                print(f"  Token issued at: {token_issued_at}")
-                print(f"  Password changed at: {user.password_changed_at}")
                 logger.warning(
                     f"Token rejected: issued at {token_issued_at}, "
                     f"password changed at {user.password_changed_at}"
@@ -171,9 +151,7 @@ async def get_current_user(
                     headers={"WWW-Authenticate": "Bearer"},
                 )
 
-    print(f"User found: {user.email}, id: {user.id}")
-    print("="*80 + "\n")
-    logger.info(f"User found: {user.email}, id: {user.id}")
+    logger.debug("User found: email=%s id=%s", user.email, user.id)
     return user
 
 
@@ -325,7 +303,7 @@ async def require_active_billing(
     """
     課金ステータスチェック（Phase 1: 機能制限）
 
-    billing_status が past_due または canceled の場合、
+    billing_status が past_due / trial_expired / payment_failed / canceled の場合、
     書き込み操作を制限し 402 Payment Required を返す。
 
     free または active の場合は制限なし。
@@ -342,7 +320,7 @@ async def require_active_billing(
         Staff: 課金ステータスが有効な場合
 
     Raises:
-        HTTPException: 課金ステータスが past_due/canceled の場合
+        HTTPException: 課金ステータスが past_due/trial_expired/payment_failed/canceled の場合
     """
     from app import crud
     from app.models.enums import BillingStatus
@@ -375,7 +353,12 @@ async def require_active_billing(
         await db.commit()
 
     # 課金ステータスチェック
-    if billing.billing_status in [BillingStatus.past_due, BillingStatus.canceled]:
+    if billing.billing_status in [
+        BillingStatus.past_due,
+        BillingStatus.trial_expired,
+        BillingStatus.payment_failed,
+        BillingStatus.canceled,
+    ]:
         logger.warning(
             f"Billing restriction: office_id={office_id}, "
             f"status={billing.billing_status}, staff_id={current_staff.id}"

--- a/app/api/v1/endpoints/billing.py
+++ b/app/api/v1/endpoints/billing.py
@@ -2,9 +2,9 @@
 Billing API エンドポイント (Phase 2)
 """
 from typing import Annotated
-from datetime import datetime, timezone
 from uuid import UUID
 import json
+from datetime import datetime, timezone
 from fastapi import APIRouter, Depends, HTTPException, status, Request, Header
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.exc import IntegrityError
@@ -86,6 +86,32 @@ async def get_billing_status(
         )
         logger.info(f"Auto-created billing record: id={billing.id}, office_id={office_id}")
 
+    if billing.trial_end_date and billing.trial_end_date < datetime.now(timezone.utc):
+        expired_status = None
+        if billing.billing_status == BillingStatus.free:
+            expired_status = BillingStatus.trial_expired
+        elif billing.billing_status == BillingStatus.early_payment:
+            expired_status = BillingStatus.active
+
+        if expired_status:
+            billing = await crud.billing.update_status(
+                db=db,
+                billing_id=billing.id,
+                status=expired_status,
+                auto_commit=True
+            )
+            logger.info(
+                "Expired trial billing corrected during status fetch: "
+                f"billing_id={billing.id}, office_id={office_id}, "
+                f"status={expired_status.value}"
+            )
+
+    if billing is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=ja.BILLING_INFO_NOT_FOUND
+        )
+
     return BillingStatusResponse(
         billing_status=billing.billing_status,
         trial_end_date=billing.trial_end_date,
@@ -149,49 +175,18 @@ async def create_checkout_session(
 
     # 既にCustomer IDがある場合
     if billing.stripe_customer_id:
-        # 既存のCustomerでCheckout Sessionを作成
-        try:
-            # Trial期間が未来の場合のみtrial_endを設定
-            now = datetime.now(timezone.utc)
-            subscription_data_params = {
-                'metadata': {
-                    'office_id': str(office_id),
-                    'office_name': office.name,
-                    'created_by_user_id': str(current_user.id),
-                }
-            }
-
-            # Trial期間が未来の場合のみtrial_endを設定（past_due状態では設定しない）
-            if billing.trial_end_date and billing.trial_end_date > now:
-                subscription_data_params['trial_end'] = int(billing.trial_end_date.timestamp())
-
-            checkout_session = stripe.checkout.Session.create(
-                mode='subscription',
-                customer=billing.stripe_customer_id,
-                line_items=[{
-                    'price': settings.STRIPE_PRICE_ID,
-                    'quantity': 1
-                }],
-                subscription_data=subscription_data_params,
-                automatic_tax={'enabled': True},
-                customer_update={'address': 'auto'},
-                billing_address_collection='required',
-                payment_method_types=['card'],
-                success_url=f"{settings.FRONTEND_URL}/admin?tab=plan&success=true",
-                cancel_url=f"{settings.FRONTEND_URL}/admin?tab=plan&canceled=true",
-            )
-
-            return {
-                "session_id": checkout_session.id,
-                "url": checkout_session.url
-            }
-
-        except Exception as e:
-            logger.error(f"Stripe Checkout Session作成エラー: {e}")
-            raise HTTPException(
-                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-                detail=ja.BILLING_CHECKOUT_SESSION_FAILED
-            )
+        return await billing_service.create_checkout_session_for_existing_customer(
+            db=db,
+            billing_id=billing.id,
+            office_id=office_id,
+            office_name=office.name,
+            user_id=current_user.id,
+            stripe_customer_id=billing.stripe_customer_id,
+            trial_end_date=billing.trial_end_date,
+            stripe_secret_key=get_stripe_secret_key(),
+            stripe_price_id=settings.STRIPE_PRICE_ID,
+            frontend_url=settings.FRONTEND_URL
+        )
 
     # Customer IDがない場合: サービス層で作成
     return await billing_service.create_checkout_session_with_customer(
@@ -323,6 +318,19 @@ async def stripe_webhook(
     event_data: dict = event_dict['data']['object']
     event_id: str = event_dict.get('id', 'unknown')
 
+    logger.info(
+        "[Webhook:%s] Received event type=%s object_id=%s customer=%s "
+        "subscription=%s payment_intent=%s invoice=%s status=%s",
+        event_id,
+        event_type,
+        event_data.get('id'),
+        event_data.get('customer'),
+        event_data.get('subscription'),
+        event_data.get('payment_intent'),
+        event_data.get('invoice'),
+        event_data.get('status'),
+    )
+
     # 【Phase 7】冪等性チェック: 既に処理済みのイベントはスキップ
     is_processed = await crud.webhook_event.is_event_processed(db=db, event_id=event_id)
     if is_processed:
@@ -376,7 +384,18 @@ async def stripe_webhook(
 
         else:
             # 未対応のイベントタイプ
-            logger.info(f"[Webhook:{event_id}] Unhandled event type: {event_type}")
+            logger.info(
+                "[Webhook:%s] Unhandled event type=%s object_id=%s customer=%s "
+                "subscription=%s payment_intent=%s invoice=%s status=%s",
+                event_id,
+                event_type,
+                event_data.get('id'),
+                event_data.get('customer'),
+                event_data.get('subscription'),
+                event_data.get('payment_intent'),
+                event_data.get('invoice'),
+                event_data.get('status'),
+            )
 
         return {"status": "success"}
 

--- a/app/crud/crud_billing.py
+++ b/app/crud/crud_billing.py
@@ -174,7 +174,7 @@ class CRUDBilling(CRUDBase[Billing, BillingCreate, BillingUpdate]):
 
         Returns:
             True: active, early_payment, canceling（期間終了まで利用可能）
-            False: free, past_due, canceled
+            False: free, past_due, trial_expired, payment_failed, canceled
         """
         return billing.billing_status in [
             BillingStatus.active,
@@ -198,7 +198,7 @@ class CRUDBilling(CRUDBase[Billing, BillingCreate, BillingUpdate]):
 
         Returns:
             True: early_payment, active, canceling（期間終了まで利用可能）
-            False: free, past_due, canceled
+            False: free, past_due, trial_expired, payment_failed, canceled
         """
         return billing.billing_status in [
             BillingStatus.early_payment,
@@ -211,10 +211,14 @@ class CRUDBilling(CRUDBase[Billing, BillingCreate, BillingUpdate]):
         支払いアクションが必要かを判定
 
         Returns:
-            True: past_due のみ
+            True: past_due, trial_expired, payment_failed
             False: その他
         """
-        return billing.billing_status == BillingStatus.past_due
+        return billing.billing_status in [
+            BillingStatus.past_due,
+            BillingStatus.trial_expired,
+            BillingStatus.payment_failed,
+        ]
 
     # ========================================
     # ステータスメッセージ取得メソッド
@@ -235,6 +239,8 @@ class CRUDBilling(CRUDBase[Billing, BillingCreate, BillingUpdate]):
             BillingStatus.early_payment: "課金設定済み（無料期間中）",
             BillingStatus.active: "課金中",
             BillingStatus.past_due: "支払い遅延",
+            BillingStatus.trial_expired: "無料期間終了",
+            BillingStatus.payment_failed: "支払い失敗",
             BillingStatus.canceling: "キャンセル予定",
             BillingStatus.canceled: "キャンセル済み",
         }
@@ -270,6 +276,8 @@ class CRUDBilling(CRUDBase[Billing, BillingCreate, BillingUpdate]):
         messages = {
             BillingStatus.free: "課金設定を行うと、より多くの機能が利用できます。",
             BillingStatus.past_due: "支払い方法を更新してください。",
+            BillingStatus.trial_expired: "サブスクリプション登録を行ってください。",
+            BillingStatus.payment_failed: "支払い方法を更新し、再決済を行ってください。",
             BillingStatus.canceling: "キャンセルの取り消しができます。",
             BillingStatus.canceled: "再契約することで、サービスを再開できます。",
         }

--- a/app/crud/crud_webhook_event.py
+++ b/app/crud/crud_webhook_event.py
@@ -166,6 +166,36 @@ class CRUDWebhookEvent(CRUDBase[WebhookEvent, WebhookEventCreate, WebhookEventUp
         result = await db.execute(query)
         return list(result.scalars().all())
 
+    async def has_recent_successful_event(
+        self,
+        db: AsyncSession,
+        *,
+        billing_id: UUID,
+        event_type: str,
+        since: datetime
+    ) -> bool:
+        """
+        指定Billingに直近の成功Webhookイベントが存在するか確認
+
+        Args:
+            db: データベースセッション
+            billing_id: Billing ID
+            event_type: イベントタイプ
+            since: この日時以降のイベントのみ対象
+
+        Returns:
+            True: 存在する, False: 存在しない
+        """
+        result = await db.execute(
+            select(self.model.id)
+            .where(self.model.billing_id == billing_id)
+            .where(self.model.event_type == event_type)
+            .where(self.model.status == "success")
+            .where(self.model.processed_at >= since)
+            .limit(1)
+        )
+        return result.scalar_one_or_none() is not None
+
     async def cleanup_old_events(
         self,
         db: AsyncSession,

--- a/app/main.py
+++ b/app/main.py
@@ -17,7 +17,7 @@ from app.core.config import settings # settingsをインポート
 from app.api.v1.api import api_router
 from app.scheduler.calendar_sync_scheduler import calendar_sync_scheduler
 from app.scheduler.cleanup_scheduler import cleanup_scheduler
-from app.scheduler.billing_scheduler import billing_scheduler
+from app.scheduler import billing_scheduler
 from app.scheduler import deadline_notification_scheduler
 
 # ログ設定（環境に応じてレベルを変更）

--- a/app/models/enums.py
+++ b/app/models/enums.py
@@ -48,7 +48,9 @@ class BillingStatus(str, enum.Enum):
     free = 'free'                    # 無料トライアル
     early_payment = 'early_payment'  # 早期支払い完了（無料期間中に課金設定済み）
     active = 'active'                # 課金中
-    past_due = 'past_due'            # 支払い遅延
+    past_due = 'past_due'            # 互換用の支払い対応必要状態
+    trial_expired = 'trial_expired'  # 無料期間終了・未課金
+    payment_failed = 'payment_failed'  # 支払い失敗
     canceling = 'canceling'          # キャンセル予定（期間終了時にキャンセル）
     canceled = 'canceled'            # キャンセル済み
 

--- a/app/scheduler/billing_scheduler.py
+++ b/app/scheduler/billing_scheduler.py
@@ -82,15 +82,21 @@ def start():
         name='スケジュールキャンセル期限チェック'
     )
 
-    billing_scheduler.start()
-    logger.info(
-        "[BILLING_SCHEDULER] Started successfully\n"
-        "  - check_trial_expiration: Daily at 0:00 UTC\n"
-        "  - check_scheduled_cancellation: Daily at 0:05 UTC"
-    )
+    if not billing_scheduler.running:
+        billing_scheduler.start()
+        logger.info(
+            "[BILLING_SCHEDULER] Started successfully\n"
+            "  - check_trial_expiration: Daily at 0:00 UTC\n"
+            "  - check_scheduled_cancellation: Daily at 0:05 UTC"
+        )
+    else:
+        logger.info("[BILLING_SCHEDULER] Already running; jobs refreshed")
 
 
 def shutdown():
     """スケジューラーをシャットダウン"""
-    billing_scheduler.shutdown(wait=True)
-    logger.info("[BILLING_SCHEDULER] Shutdown completed")
+    if billing_scheduler.running:
+        billing_scheduler.shutdown(wait=True)
+        logger.info("[BILLING_SCHEDULER] Shutdown completed")
+    else:
+        logger.info("[BILLING_SCHEDULER] Shutdown skipped because scheduler is not running")

--- a/app/services/billing_service.py
+++ b/app/services/billing_service.py
@@ -11,7 +11,7 @@ Billing Service層
 """
 
 import logging
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from typing import Optional, Dict, Any
 from uuid import UUID
 
@@ -34,6 +34,191 @@ class BillingService:
     データ整合性を保証します。
     """
 
+    def _normalize_trial_end_date(self, trial_end_date: Optional[datetime]) -> Optional[datetime]:
+        if not trial_end_date:
+            return None
+
+        if trial_end_date.tzinfo is not None:
+            return trial_end_date
+
+        return trial_end_date.replace(tzinfo=timezone.utc)
+
+    async def correct_expired_free_billing_before_checkout(
+        self,
+        db: AsyncSession,
+        *,
+        billing_id: UUID,
+        office_id: UUID,
+        trial_end_date: Optional[datetime],
+        auto_commit: bool = False
+    ) -> Optional[datetime]:
+        """
+        期限切れfreeが残っている場合、Checkout前にtrial_expiredへ補正する。
+
+        Returns:
+            timezone-awareなtrial_end_date。trial_end_dateがない場合はNone。
+        """
+        now = datetime.now(timezone.utc)
+        normalized_trial_end_date = self._normalize_trial_end_date(trial_end_date)
+
+        billing = await crud.billing.get(db=db, id=billing_id)
+        if (
+            billing
+            and billing.billing_status == BillingStatus.free
+            and normalized_trial_end_date
+            and normalized_trial_end_date < now
+        ):
+            await crud.billing.update_status(
+                db=db,
+                billing_id=billing_id,
+                status=BillingStatus.trial_expired,
+                auto_commit=auto_commit
+            )
+            logger.info(
+                "Expired free billing corrected before checkout: "
+                f"billing_id={billing_id}, office_id={office_id}"
+            )
+
+        return normalized_trial_end_date
+
+    def _build_checkout_subscription_data(
+        self,
+        *,
+        office_id: UUID,
+        office_name: str,
+        user_id: UUID,
+        trial_end_date: Optional[datetime],
+        now: datetime
+    ) -> Dict[str, Any]:
+        subscription_data: Dict[str, Any] = {
+            'metadata': {
+                'office_id': str(office_id),
+                'office_name': office_name,
+                'created_by_user_id': str(user_id),
+            }
+        }
+
+        if trial_end_date and trial_end_date > now:
+            subscription_data['trial_end'] = int(trial_end_date.timestamp())
+
+        return subscription_data
+
+    def _log_checkout_error(
+        self,
+        *,
+        error: Exception,
+        checkout_route: str,
+        billing_id: UUID,
+        office_id: UUID,
+        billing_status: Optional[BillingStatus],
+        trial_end_date: Optional[datetime],
+        has_stripe_customer_id: bool
+    ) -> None:
+        logger.error(
+            "Checkout session creation failed: "
+            f"stripe_error_type={type(error).__name__}, "
+            f"checkout_route={checkout_route}, "
+            f"billing_id={billing_id}, "
+            f"office_id={office_id}, "
+            f"billing_status={billing_status.value if billing_status else None}, "
+            f"trial_end_date={trial_end_date.isoformat() if trial_end_date else None}, "
+            f"has_stripe_customer_id={has_stripe_customer_id}"
+        )
+
+    async def create_checkout_session_for_existing_customer(
+        self,
+        db: AsyncSession,
+        *,
+        billing_id: UUID,
+        office_id: UUID,
+        office_name: str,
+        user_id: UUID,
+        stripe_customer_id: str,
+        trial_end_date: Optional[datetime],
+        stripe_secret_key: str,
+        stripe_price_id: str,
+        frontend_url: str
+    ) -> Dict[str, str]:
+        """
+        既存Stripe CustomerでCheckout Sessionを作成する。
+        """
+        billing_status: Optional[BillingStatus] = None
+        normalized_trial_end_date: Optional[datetime] = None
+        try:
+            billing = await crud.billing.get(db=db, id=billing_id)
+            if billing:
+                billing_status = billing.billing_status
+
+            now = datetime.now(timezone.utc)
+            normalized_trial_end_date = await self.correct_expired_free_billing_before_checkout(
+                db=db,
+                billing_id=billing_id,
+                office_id=office_id,
+                trial_end_date=trial_end_date,
+                auto_commit=False
+            )
+
+            stripe.api_key = stripe_secret_key
+            checkout_session = stripe.checkout.Session.create(
+                mode='subscription',
+                customer=stripe_customer_id,
+                line_items=[{
+                    'price': stripe_price_id,
+                    'quantity': 1
+                }],
+                subscription_data=self._build_checkout_subscription_data(
+                    office_id=office_id,
+                    office_name=office_name,
+                    user_id=user_id,
+                    trial_end_date=normalized_trial_end_date,
+                    now=now
+                ),
+                automatic_tax={'enabled': True},
+                customer_update={'address': 'auto'},
+                billing_address_collection='required',
+                payment_method_types=['card'],
+                success_url=f"{frontend_url}/admin?tab=plan&success=true",
+                cancel_url=f"{frontend_url}/admin?tab=plan&canceled=true",
+            )
+
+            await db.commit()
+
+            return {
+                "session_id": checkout_session.id,
+                "url": checkout_session.url
+            }
+
+        except stripe.error.StripeError as e:
+            await db.rollback()
+            self._log_checkout_error(
+                error=e,
+                checkout_route="existing_customer",
+                billing_id=billing_id,
+                office_id=office_id,
+                billing_status=billing_status,
+                trial_end_date=normalized_trial_end_date,
+                has_stripe_customer_id=True
+            )
+            raise HTTPException(
+                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                detail=ja.BILLING_CHECKOUT_SESSION_FAILED
+            )
+        except Exception as e:
+            await db.rollback()
+            self._log_checkout_error(
+                error=e,
+                checkout_route="existing_customer",
+                billing_id=billing_id,
+                office_id=office_id,
+                billing_status=billing_status,
+                trial_end_date=normalized_trial_end_date,
+                has_stripe_customer_id=True
+            )
+            raise HTTPException(
+                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                detail=ja.BILLING_CHECKOUT_SESSION_FAILED
+            )
+
     async def create_checkout_session_with_customer(
         self,
         db: AsyncSession,
@@ -43,7 +228,7 @@ class BillingService:
         office_name: str,
         user_email: str,
         user_id: UUID,
-        trial_end_date: datetime,
+        trial_end_date: Optional[datetime],
         stripe_secret_key: str,
         stripe_price_id: str,
         frontend_url: str
@@ -71,7 +256,23 @@ class BillingService:
         Raises:
             HTTPException: Stripe API呼び出しエラー
         """
+        billing_status: Optional[BillingStatus] = None
+        normalized_trial_end_date: Optional[datetime] = None
+        customer_id: Optional[str] = None
         try:
+            billing = await crud.billing.get(db=db, id=billing_id)
+            if billing:
+                billing_status = billing.billing_status
+
+            now = datetime.now(timezone.utc)
+            normalized_trial_end_date = await self.correct_expired_free_billing_before_checkout(
+                db=db,
+                billing_id=billing_id,
+                office_id=office_id,
+                trial_end_date=trial_end_date,
+                auto_commit=False
+            )
+
             # 1. Stripe APIでCustomerを作成（DB操作の前に実行）
             stripe.api_key = stripe_secret_key
             customer = stripe.Customer.create(
@@ -102,14 +303,13 @@ class BillingService:
                     'price': stripe_price_id,
                     'quantity': 1
                 }],
-                subscription_data={
-                    'trial_end': int(trial_end_date.timestamp()),
-                    'metadata': {
-                        'office_id': str(office_id),
-                        'office_name': office_name,
-                        'created_by_user_id': str(user_id),
-                    }
-                },
+                subscription_data=self._build_checkout_subscription_data(
+                    office_id=office_id,
+                    office_name=office_name,
+                    user_id=user_id,
+                    trial_end_date=normalized_trial_end_date,
+                    now=now
+                ),
                 automatic_tax={'enabled': True},
                 customer_update={'address': 'auto'},
                 billing_address_collection='required',
@@ -131,7 +331,15 @@ class BillingService:
         except stripe.error.StripeError as e:
             # Stripeエラー時はロールバック
             await db.rollback()
-            logger.error(f"Stripe API error: {e}")
+            self._log_checkout_error(
+                error=e,
+                checkout_route="new_customer",
+                billing_id=billing_id,
+                office_id=office_id,
+                billing_status=billing_status,
+                trial_end_date=normalized_trial_end_date,
+                has_stripe_customer_id=customer_id is not None
+            )
             raise HTTPException(
                 status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
                 detail=ja.BILLING_CHECKOUT_SESSION_FAILED
@@ -139,7 +347,15 @@ class BillingService:
         except Exception as e:
             # その他のエラー時もロールバック
             await db.rollback()
-            logger.error(f"Checkout session creation error: {e}")
+            self._log_checkout_error(
+                error=e,
+                checkout_route="new_customer",
+                billing_id=billing_id,
+                office_id=office_id,
+                billing_status=billing_status,
+                trial_end_date=normalized_trial_end_date,
+                has_stripe_customer_id=customer_id is not None
+            )
             raise HTTPException(
                 status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
                 detail=ja.BILLING_CHECKOUT_SESSION_FAILED
@@ -177,7 +393,7 @@ class BillingService:
             )
 
             if not billing:
-                logger.warning(f"[Webhook:{event_id}] Billing not found for customer {customer_id} - skipping (possibly test data)")
+                logger.info(f"[Webhook:{event_id}] Billing not found for customer {customer_id} - skipping (possibly test data)")
 
                 await crud.webhook_event.create_event_record(
                     db=db,
@@ -265,7 +481,7 @@ class BillingService:
             )
 
             if not billing:
-                logger.warning(f"[Webhook:{event_id}] Billing not found for customer {customer_id} - skipping (possibly test data)")
+                logger.info(f"[Webhook:{event_id}] Billing not found for customer {customer_id} - skipping (possibly test data)")
 
                 await crud.webhook_event.create_event_record(
                     db=db,
@@ -281,12 +497,17 @@ class BillingService:
                 return
 
             # 1. ステータス更新（auto_commit=False）
-            await crud.billing.update_status(
-                db=db,
-                billing_id=billing.id,
-                status=BillingStatus.past_due,
-                auto_commit=False
-            )
+            now = datetime.now(timezone.utc)
+            trial_end_date = self._normalize_trial_end_date(billing.trial_end_date)
+            is_trial_active = bool(trial_end_date and trial_end_date > now)
+
+            if not is_trial_active:
+                await crud.billing.update_status(
+                    db=db,
+                    billing_id=billing.id,
+                    status=BillingStatus.payment_failed,
+                    auto_commit=False
+                )
 
             # 2. Webhookイベント記録（auto_commit=False）
             await crud.webhook_event.create_event_record(
@@ -361,6 +582,29 @@ class BillingService:
             if not billing:
                 raise ValueError(f"Billing not found for customer {customer_id}")
 
+            previous_status = billing.billing_status
+            logger.info(
+                "[Webhook:%s] Subscription created payload: customer_id=%s, "
+                "subscription_id=%s, stripe_status=%s, cancel_at_period_end=%s, "
+                "cancel_at=%s, trial_start=%s, trial_end=%s, latest_invoice=%s, "
+                "billing_id=%s, office_id=%s, previous_billing_status=%s, "
+                "db_trial_end_date=%s, db_stripe_subscription_id=%s",
+                event_id,
+                customer_id,
+                subscription_data.get('id'),
+                subscription_data.get('status'),
+                subscription_data.get('cancel_at_period_end'),
+                subscription_data.get('cancel_at'),
+                subscription_data.get('trial_start'),
+                subscription_data.get('trial_end'),
+                subscription_data.get('latest_invoice'),
+                billing.id,
+                billing.office_id,
+                previous_status.value if previous_status else None,
+                billing.trial_end_date.isoformat() if billing.trial_end_date else None,
+                billing.stripe_subscription_id,
+            )
+
             # 2. Subscription情報を更新（auto_commit=False）
             billing = await crud.billing.update_stripe_subscription(
                 db=db,
@@ -372,14 +616,27 @@ class BillingService:
 
             # 3. ステータス判定: 無料期間中 → early_payment、期限切れ → active
             now = datetime.now(timezone.utc)
+            trial_end_date = self._normalize_trial_end_date(billing.trial_end_date)
 
             is_trial_active = (
-                billing.billing_status == BillingStatus.free and
-                billing.trial_end_date and
-                billing.trial_end_date > now
+                trial_end_date and
+                trial_end_date > now
             )
 
             new_status = BillingStatus.early_payment if is_trial_active else BillingStatus.active
+            logger.info(
+                "[Webhook:%s] Subscription created status decision: billing_id=%s, "
+                "previous_status=%s, new_status=%s, db_trial_end_date=%s, "
+                "normalized_trial_end_date=%s, now=%s, is_trial_active=%s",
+                event_id,
+                billing.id,
+                previous_status.value if previous_status else None,
+                new_status.value,
+                billing.trial_end_date.isoformat() if billing.trial_end_date else None,
+                trial_end_date.isoformat() if trial_end_date else None,
+                now.isoformat(),
+                is_trial_active,
+            )
             await crud.billing.update_status(
                 db=db,
                 billing_id=billing.id,
@@ -427,7 +684,18 @@ class BillingService:
 
         except Exception as e:
             await db.rollback()
-            logger.error(f"[Webhook:{event_id}] Subscription creation processing error: {e}")
+            logger.exception(
+                "[Webhook:%s] Subscription creation processing error: "
+                "customer_id=%s, subscription_id=%s, stripe_status=%s, "
+                "cancel_at_period_end=%s, cancel_at=%s, latest_invoice=%s",
+                event_id,
+                subscription_data.get('customer'),
+                subscription_data.get('id'),
+                subscription_data.get('status'),
+                subscription_data.get('cancel_at_period_end'),
+                subscription_data.get('cancel_at'),
+                subscription_data.get('latest_invoice'),
+            )
             raise
 
     async def process_subscription_updated(
@@ -457,9 +725,29 @@ class BillingService:
             cancel_at_period_end = subscription_data.get('cancel_at_period_end', False)
             cancel_at = subscription_data.get('cancel_at')
             subscription_status = subscription_data.get('status')
+            subscription_id = subscription_data.get('id')
 
             # デバッグログ: イベントの詳細を記録
-            logger.info(f"[Webhook:{event_id}] Subscription updated - customer_id={customer_id}, cancel_at_period_end={cancel_at_period_end}, cancel_at={cancel_at}, status={subscription_status}")
+            logger.info(
+                "[Webhook:%s] Subscription updated payload: customer_id=%s, "
+                "subscription_id=%s, stripe_status=%s, cancel_at_period_end=%s, "
+                "cancel_at=%s, canceled_at=%s, cancellation_reason=%s, "
+                "trial_start=%s, trial_end=%s, current_period_end=%s, latest_invoice=%s",
+                event_id,
+                customer_id,
+                subscription_id,
+                subscription_status,
+                cancel_at_period_end,
+                cancel_at,
+                subscription_data.get('canceled_at'),
+                subscription_data.get('cancellation_details', {}).get('reason')
+                if isinstance(subscription_data.get('cancellation_details'), dict)
+                else None,
+                subscription_data.get('trial_start'),
+                subscription_data.get('trial_end'),
+                subscription_data.get('current_period_end'),
+                subscription_data.get('latest_invoice'),
+            )
 
             billing = await crud.billing.get_by_stripe_customer_id(
                 db=db,
@@ -467,7 +755,7 @@ class BillingService:
             )
 
             if not billing:
-                logger.warning(f"[Webhook:{event_id}] Billing not found for customer {customer_id} - skipping (possibly test data)")
+                logger.info(f"[Webhook:{event_id}] Billing not found for customer {customer_id} - skipping (possibly test data)")
 
                 await crud.webhook_event.create_event_record(
                     db=db,
@@ -487,11 +775,71 @@ class BillingService:
                 )
                 return
 
-            # 現在のbilling_statusをログに記録
-            logger.info(f"[Webhook:{event_id}] Current billing_status={billing.billing_status}")
+            previous_status = billing.billing_status
+            logger.info(
+                "[Webhook:%s] Current billing before subscription update: "
+                "billing_id=%s, office_id=%s, billing_status=%s, "
+                "db_trial_end_date=%s, db_subscription_start_date=%s, "
+                "db_last_payment_date=%s, db_scheduled_cancel_at=%s, "
+                "db_stripe_subscription_id=%s",
+                event_id,
+                billing.id,
+                billing.office_id,
+                previous_status.value if previous_status else None,
+                billing.trial_end_date.isoformat() if billing.trial_end_date else None,
+                billing.subscription_start_date.isoformat() if billing.subscription_start_date else None,
+                billing.last_payment_date.isoformat() if billing.last_payment_date else None,
+                billing.scheduled_cancel_at.isoformat() if billing.scheduled_cancel_at else None,
+                billing.stripe_subscription_id,
+            )
+
+            now = datetime.now(timezone.utc)
+            trial_end_date = self._normalize_trial_end_date(billing.trial_end_date)
+            is_stale_unpaid_expired_trial = (
+                billing.billing_status in [BillingStatus.free, BillingStatus.canceling]
+                and trial_end_date is not None
+                and trial_end_date < now
+                and billing.last_payment_date is None
+                and billing.subscription_start_date is None
+            )
+            should_cancel_trial_expired_immediately = (
+                (billing.billing_status == BillingStatus.trial_expired or is_stale_unpaid_expired_trial)
+                and (cancel_at_period_end or cancel_at)
+            )
+            logger.info(
+                "[Webhook:%s] Subscription update status decision flags: billing_id=%s, "
+                "previous_status=%s, stripe_status=%s, is_stale_unpaid_expired_trial=%s, "
+                "should_cancel_trial_expired_immediately=%s, cancel_at_period_end=%s, "
+                "cancel_at=%s, normalized_trial_end_date=%s, now=%s",
+                event_id,
+                billing.id,
+                previous_status.value if previous_status else None,
+                subscription_status,
+                is_stale_unpaid_expired_trial,
+                should_cancel_trial_expired_immediately,
+                cancel_at_period_end,
+                cancel_at,
+                trial_end_date.isoformat() if trial_end_date else None,
+                now.isoformat(),
+            )
 
             # スケジュールされたキャンセル日時を保存
-            if cancel_at:
+            if should_cancel_trial_expired_immediately:
+                await crud.billing.update(
+                    db=db,
+                    db_obj=billing,
+                    obj_in={
+                        "billing_status": BillingStatus.canceled,
+                        "scheduled_cancel_at": None,
+                    },
+                    auto_commit=False
+                )
+                logger.info(
+                    f"[Webhook:{event_id}] Trial expired subscription canceled immediately "
+                    f"for billing_id={billing.id}, previous_status={previous_status.value if previous_status else None}, "
+                    f"reason=cancel_signal_on_trial_expired_or_stale_unpaid_expired_trial"
+                )
+            elif cancel_at:
                 cancel_at_datetime = datetime.fromtimestamp(cancel_at, tz=timezone.utc)
                 await crud.billing.update(
                     db=db,
@@ -510,7 +858,7 @@ class BillingService:
                 logger.info(f"[Webhook:{event_id}] Scheduled cancellation cleared")
 
             # cancel_at_period_end=true または cancel_at が設定されている場合、キャンセル予定状態に
-            if cancel_at_period_end or cancel_at:
+            if not should_cancel_trial_expired_immediately and (cancel_at_period_end or cancel_at):
                 await crud.billing.update_status(
                     db=db,
                     billing_id=billing.id,
@@ -521,7 +869,12 @@ class BillingService:
                 logger.info(f"[Webhook:{event_id}] Subscription set to canceling - cancel_at_period_end={cancel_at_period_end}, cancel_at={cancel_at}")
 
             # キャンセルが完全にクリアされた場合（cancel_at_period_end=false かつ cancel_at=null）、元のステータスに復元
-            elif not cancel_at_period_end and not cancel_at and billing.billing_status == BillingStatus.canceling:
+            elif (
+                not should_cancel_trial_expired_immediately
+                and not cancel_at_period_end
+                and not cancel_at
+                and billing.billing_status == BillingStatus.canceling
+            ):
                 # 元のステータスを判定: trial期間内 or 課金期間中
                 now = datetime.now(timezone.utc)
                 is_in_trial = now < billing.trial_end_date
@@ -587,10 +940,31 @@ class BillingService:
 
             # commit
             await db.commit()
+            logger.info(
+                "[Webhook:%s] Subscription update committed: billing_id=%s, "
+                "previous_status=%s, cancel_at_period_end=%s, cancel_at=%s, "
+                "stripe_status=%s",
+                event_id,
+                billing.id,
+                previous_status.value if previous_status else None,
+                cancel_at_period_end,
+                cancel_at,
+                subscription_status,
+            )
 
         except Exception as e:
             await db.rollback()
-            logger.error(f"[Webhook:{event_id}] Subscription update processing error: {e}")
+            logger.exception(
+                "[Webhook:%s] Subscription update processing error: "
+                "customer_id=%s, subscription_id=%s, stripe_status=%s, "
+                "cancel_at_period_end=%s, cancel_at=%s",
+                event_id,
+                subscription_data.get('customer'),
+                subscription_data.get('id'),
+                subscription_data.get('status'),
+                subscription_data.get('cancel_at_period_end'),
+                subscription_data.get('cancel_at'),
+            )
             raise
 
     async def process_subscription_deleted(
@@ -618,7 +992,7 @@ class BillingService:
             )
 
             if not billing:
-                logger.warning(f"[Webhook:{event_id}] Billing not found for customer {customer_id} - skipping (possibly test data)")
+                logger.info(f"[Webhook:{event_id}] Billing not found for customer {customer_id} - skipping (possibly test data)")
 
                 await crud.webhook_event.create_event_record(
                     db=db,
@@ -633,12 +1007,41 @@ class BillingService:
                 )
                 return
 
+            previous_status = billing.billing_status
+            recent_payment_failed_cutoff = datetime.now(timezone.utc) - timedelta(minutes=10)
+            has_recent_payment_failed = await crud.webhook_event.has_recent_successful_event(
+                db=db,
+                billing_id=billing.id,
+                event_type="invoice.payment_failed",
+                since=recent_payment_failed_cutoff
+            )
+            new_status = (
+                BillingStatus.payment_failed
+                if has_recent_payment_failed
+                else BillingStatus.canceled
+            )
+            logger.info(
+                "[Webhook:%s] Subscription deleted payload: customer_id=%s, "
+                "billing_id=%s, office_id=%s, previous_status=%s, "
+                "db_stripe_subscription_id=%s, has_recent_payment_failed=%s, "
+                "recent_payment_failed_cutoff=%s, new_status=%s",
+                event_id,
+                customer_id,
+                billing.id,
+                billing.office_id,
+                previous_status.value if previous_status else None,
+                billing.stripe_subscription_id,
+                has_recent_payment_failed,
+                recent_payment_failed_cutoff.isoformat(),
+                new_status.value,
+            )
+
             # 1. ステータス更新とスケジュールキャンセルのクリア（auto_commit=False）
             await crud.billing.update(
                 db=db,
                 db_obj=billing,
                 obj_in={
-                    "billing_status": BillingStatus.canceled,
+                    "billing_status": new_status,
                     "scheduled_cancel_at": None
                 },
                 auto_commit=False
@@ -662,13 +1065,18 @@ class BillingService:
                 db=db,
                 actor_id=None,
                 actor_role="system",
-                action="billing.subscription_canceled",
+                action=(
+                    "billing.subscription_deleted_after_payment_failed"
+                    if has_recent_payment_failed
+                    else "billing.subscription_canceled"
+                ),
                 target_type="billing",
                 target_id=billing.id,
                 office_id=billing.office_id,
                 details={
                     "event_id": event_id,
                     "event_type": "customer.subscription.deleted",
+                    "has_recent_payment_failed": has_recent_payment_failed,
                     "source": "stripe_webhook"
                 },
                 auto_commit=False
@@ -677,9 +1085,20 @@ class BillingService:
             # 4. commit
             await db.commit()
 
-            logger.info(f"[Webhook:{event_id}] Subscription canceled for billing_id={billing.id}")
+            logger.info(
+                "[Webhook:%s] Subscription deleted committed: billing_id=%s, "
+                "previous_status=%s, new_status=%s",
+                event_id,
+                billing.id,
+                previous_status.value if previous_status else None,
+                new_status.value,
+            )
 
         except Exception as e:
             await db.rollback()
-            logger.error(f"[Webhook:{event_id}] Subscription deletion processing error: {e}")
+            logger.exception(
+                "[Webhook:%s] Subscription deletion processing error: customer_id=%s",
+                event_id,
+                customer_id,
+            )
             raise

--- a/app/services/staff_profile_service.py
+++ b/app/services/staff_profile_service.py
@@ -1,4 +1,5 @@
 """スタッフプロフィール関連のサービス"""
+import logging
 import re
 import secrets
 from datetime import datetime, timedelta, timezone
@@ -16,6 +17,7 @@ from app.core import mail
 from app.messages import ja
 
 pwd_context = CryptContext(schemes=["bcrypt"], deprecated="auto")
+logger = logging.getLogger(__name__)
 
 
 class RateLimitExceededError(Exception):
@@ -192,7 +194,7 @@ class StaffProfileService:
                 )
             except Exception as e:
                 # メール送信失敗はログに記録するが、処理は続行
-                print(f"パスワード変更通知メール送信失敗: {e}")
+                logger.warning("Password change notification email failed: %s", e)
 
             # commit前にupdated_atを取得（MissingGreenletエラー対策）
             updated_at = staff.updated_at
@@ -491,7 +493,7 @@ class StaffProfileService:
             )
         except Exception as e:
             # メール送信失敗はログに記録するが、リクエストは成功とする
-            print(f"確認メール送信失敗: {e}")
+            logger.warning("Email change verification email failed: %s", e)
 
         # 通知メール送信（旧メールアドレス）
         try:
@@ -501,7 +503,7 @@ class StaffProfileService:
                 new_email=email_request.new_email
             )
         except Exception as e:
-            print(f"通知メール送信失敗: {e}")
+            logger.warning("Email change notification email failed: %s", e)
 
         await db.commit()
 
@@ -528,10 +530,10 @@ class StaffProfileService:
         6. 旧メールアドレスに完了通知送信
         7. 監査ログ記録
         """
-        print(f"[DEBUG SERVICE] verify_email_change started with token: {verification_token[:10]}...")
+        logger.debug("verify_email_change started")
 
         # トークンでリクエストを検索
-        print(f"[DEBUG SERVICE] Searching for email change request with token...")
+        logger.debug("Searching for email change request")
         stmt = (
             select(EmailChangeRequestModel)
             .where(EmailChangeRequestModel.verification_token == verification_token)
@@ -540,52 +542,52 @@ class StaffProfileService:
         email_request = result.scalar_one_or_none()
 
         if not email_request:
-            print(f"[DEBUG SERVICE] Email change request not found for token")
+            logger.warning("Email change request not found")
             raise HTTPException(
                 status_code=status.HTTP_400_BAD_REQUEST,
                 detail="無効な確認トークンです"
             )
 
-        print(f"[DEBUG SERVICE] Found email change request: id={email_request.id}, status={email_request.status}")
+        logger.debug("Found email change request: id=%s status=%s", email_request.id, email_request.status)
 
         # 有効期限チェック
-        print(f"[DEBUG SERVICE] Checking expiration: expires_at={email_request.expires_at}, now={datetime.now(timezone.utc)}")
+        logger.debug("Checking email change request expiration: expires_at=%s", email_request.expires_at)
         if datetime.now(timezone.utc) > email_request.expires_at:
-            print(f"[DEBUG SERVICE] Token expired")
+            logger.warning("Email change token expired")
             raise HTTPException(
                 status_code=status.HTTP_400_BAD_REQUEST,
                 detail="確認トークンの有効期限が切れています"
             )
 
         # ステータスチェック
-        print(f"[DEBUG SERVICE] Checking status: {email_request.status}")
+        logger.debug("Checking email change request status: %s", email_request.status)
         if email_request.status != "pending":
-            print(f"[DEBUG SERVICE] Status is not pending")
+            logger.warning("Email change request status is not pending: %s", email_request.status)
             raise HTTPException(
                 status_code=status.HTTP_400_BAD_REQUEST,
                 detail="この変更リクエストは既に処理されています"
             )
 
         # スタッフ情報取得
-        print(f"[DEBUG SERVICE] Fetching staff: staff_id={email_request.staff_id}")
+        logger.debug("Fetching staff for email change: staff_id=%s", email_request.staff_id)
         stmt_staff = select(Staff).where(Staff.id == email_request.staff_id)
         result_staff = await db.execute(stmt_staff)
         staff = result_staff.scalar_one_or_none()
 
         if not staff:
-            print(f"[DEBUG SERVICE] Staff not found")
+            logger.warning("Staff not found for email change: staff_id=%s", email_request.staff_id)
             raise HTTPException(
                 status_code=status.HTTP_404_NOT_FOUND,
                 detail=ja.STAFF_NOT_FOUND
             )
 
-        print(f"[DEBUG SERVICE] Staff found: id={staff.id}, email={staff.email}")
+        logger.debug("Staff found for email change: id=%s", staff.id)
 
         # 旧メールアドレスと新メールアドレスを保存（コミット後のアクセス用）
         old_email = staff.email
         new_email = email_request.new_email
         staff_name = staff.full_name
-        print(f"[DEBUG SERVICE] Updating email from {old_email} to {new_email}")
+        logger.debug("Updating staff email: staff_id=%s", staff.id)
 
         # スタッフ情報更新
         updated_at = datetime.now(timezone.utc)
@@ -596,11 +598,11 @@ class StaffProfileService:
         email_request.status = "completed"
         # verified_atは不要（updated_atで確認日時を判定）
 
-        print(f"[DEBUG SERVICE] Flushing database changes...")
+        logger.debug("Flushing email change database changes")
         await db.flush()
 
         # 監査ログ記録
-        print(f"[DEBUG SERVICE] Creating audit log...")
+        logger.debug("Creating email change audit log")
         audit_log = AuditLog(
             staff_id=staff.id,
             action="UPDATE_EMAIL",
@@ -612,7 +614,7 @@ class StaffProfileService:
         await db.flush()
 
         # 旧メールアドレスに完了通知送信
-        print(f"[DEBUG SERVICE] Sending completion email...")
+        logger.debug("Sending email change completion email")
         try:
             await mail.send_email_change_completed(
                 old_email=old_email,
@@ -620,9 +622,9 @@ class StaffProfileService:
                 new_email=new_email
             )
         except Exception as e:
-            print(f"完了通知メール送信失敗: {e}")
+            logger.warning("Email change completion email failed: %s", e)
 
-        print(f"[DEBUG SERVICE] Committing transaction...")
+        logger.debug("Committing email change transaction")
         await db.commit()
 
         # コミット後はモデル属性にアクセスできないため、保存した変数を使用
@@ -631,7 +633,7 @@ class StaffProfileService:
             "new_email": new_email,
             "updated_at": updated_at
         }
-        print(f"[DEBUG SERVICE] verify_email_change completed successfully: {result}")
+        logger.debug("verify_email_change completed successfully")
         return result
 
 

--- a/app/services/welfare_recipient_service.py
+++ b/app/services/welfare_recipient_service.py
@@ -312,7 +312,7 @@ class WelfareRecipientService:
             return result
 
         except Exception as e:
-            print(f"Error checking data integrity: {str(e)}")
+            logger.warning("Error checking data integrity: %s", e)
             result["is_valid"] = False
             result["issues"].append(f"整合性チェック中にエラーが発生しました: {str(e)}")
             return result
@@ -331,13 +331,13 @@ class WelfareRecipientService:
             修復成功フラグ
         """
         try:
-            print(f"Starting support plan repair for recipient {welfare_recipient_id}")
+            logger.debug("Starting support plan repair for recipient %s", welfare_recipient_id)
 
             # 整合性チェック
             integrity_result = WelfareRecipientService.check_data_integrity(db, welfare_recipient_id)
 
             if integrity_result["is_valid"]:
-                print("No repair needed - data is already consistent")
+                logger.debug("No support plan repair needed for recipient %s", welfare_recipient_id)
                 return True
 
             # 修復処理
@@ -349,11 +349,11 @@ class WelfareRecipientService:
                 WelfareRecipientService._repair_missing_statuses(db, welfare_recipient_id)
 
             db.commit()
-            print(f"Successfully repaired support plan for recipient {welfare_recipient_id}")
+            logger.debug("Successfully repaired support plan for recipient %s", welfare_recipient_id)
             return True
 
         except Exception as e:
-            print(f"Error during support plan repair: {str(e)}")
+            logger.warning("Error during support plan repair for recipient %s: %s", welfare_recipient_id, e)
             db.rollback()
             return False
 
@@ -395,7 +395,7 @@ class WelfareRecipientService:
                     completed_at=None
                 )
                 db.add(status)
-                print(f"Added missing status: {step.value}")
+                logger.debug("Added missing support plan status: %s", step.value)
 
     @staticmethod
     async def create_recipient_with_details(db: AsyncSession, registration_data: UserRegistrationRequest, office_id: UUID, **kwargs):

--- a/app/tasks/billing_check.py
+++ b/app/tasks/billing_check.py
@@ -25,7 +25,7 @@ async def check_trial_expiration(
     処理内容:
     - trial_end_date < now かつ billing_status が 'free' または 'early_payment' のレコードを抽出
     - billing_status を以下のように更新:
-      - free → past_due（無料期間終了、未課金）
+      - free → trial_expired（無料期間終了、未課金）
       - early_payment → active（無料期間終了、課金済み）
     - 処理件数を返す
 
@@ -70,10 +70,12 @@ async def check_trial_expiration(
     # ステータス更新
     updated_count = 0
     for billing in expired_billings:
+        old_status = billing.billing_status
+
         # 遷移先を判定
-        if billing.billing_status == BillingStatus.free:
-            new_status = BillingStatus.past_due
-        elif billing.billing_status == BillingStatus.early_payment:
+        if old_status == BillingStatus.free:
+            new_status = BillingStatus.trial_expired
+        elif old_status == BillingStatus.early_payment:
             new_status = BillingStatus.active
         else:
             continue
@@ -89,7 +91,7 @@ async def check_trial_expiration(
             f"Trial expired: office_id={billing.office_id}, "
             f"billing_id={billing.id}, "
             f"trial_end_date={billing.trial_end_date}, "
-            f"{billing.billing_status.value} → {new_status.value}"
+            f"{old_status.value} → {new_status.value}"
         )
 
         updated_count += 1

--- a/migrations/sql/q8r9s0t1u2v3_add_trial_expired_and_payment_failed_billing_status_confirm.sql
+++ b/migrations/sql/q8r9s0t1u2v3_add_trial_expired_and_payment_failed_billing_status_confirm.sql
@@ -1,0 +1,40 @@
+-- =====================================================
+-- Confirm billing_status enum and CHECK constraint
+-- =====================================================
+-- Revision ID: q8r9s0t1u2v3
+-- Purpose:
+--   q8r9s0t1u2v3 の実行前後に、billingstatus enum値、
+--   ck_billings_billing_status、既存データ件数を確認する。
+-- =====================================================
+
+-- 1. 現在のbillingstatus enum値を確認する。
+SELECT enumlabel
+FROM pg_enum
+WHERE enumtypid = 'billingstatus'::regtype
+ORDER BY enumsortorder;
+
+-- 2. 現在のbilling_status件数を確認する。
+SELECT billing_status::text AS billing_status, COUNT(*) AS count
+FROM billings
+GROUP BY billing_status::text
+ORDER BY billing_status::text;
+
+-- 3. 現在のCHECK制約を確認する。
+-- upgrade前の想定:
+--   free / early_payment / active / past_due / canceling / canceled
+-- upgrade後の想定:
+--   free / early_payment / active / past_due / trial_expired /
+--   payment_failed / canceling / canceled
+SELECT conname, pg_get_constraintdef(oid) AS definition
+FROM pg_constraint
+WHERE conrelid = 'billings'::regclass
+  AND conname = 'ck_billings_billing_status';
+
+-- 4. 新statusの件数を個別確認する。
+-- upgrade前はこのSELECTが enum input error になる場合があるため、
+-- upgrade後確認として実行する。
+SELECT billing_status::text AS billing_status, COUNT(*) AS count
+FROM billings
+WHERE billing_status::text IN ('trial_expired', 'payment_failed')
+GROUP BY billing_status::text
+ORDER BY billing_status::text;

--- a/migrations/sql/q8r9s0t1u2v3_add_trial_expired_and_payment_failed_billing_status_downgrade.sql
+++ b/migrations/sql/q8r9s0t1u2v3_add_trial_expired_and_payment_failed_billing_status_downgrade.sql
@@ -1,0 +1,65 @@
+-- =====================================================
+-- Downgrade: remove trial_expired/payment_failed billing statuses
+-- =====================================================
+-- Revision ID: q8r9s0t1u2v3
+-- Alembic file:
+--   migrations/versions/q8r9s0t1u2v3_add_trial_expired_and_payment_failed_billing_status.py
+--
+-- Rollback policy:
+--   trial_expired/payment_failed は後方互換用の past_due へ戻す。
+--
+-- Change:
+--   1. Convert trial_expired/payment_failed records to past_due.
+--   2. Drop current 8-value CHECK constraint.
+--   3. Recreate billingstatus enum with the previous 6 values.
+--   4. Recreate ck_billings_billing_status with the previous 6 values.
+-- =====================================================
+
+BEGIN;
+
+UPDATE billings
+SET billing_status = 'past_due'
+WHERE billing_status IN ('trial_expired', 'payment_failed');
+
+ALTER TABLE billings
+DROP CONSTRAINT IF EXISTS ck_billings_billing_status;
+
+ALTER TABLE billings
+ALTER COLUMN billing_status DROP DEFAULT;
+
+ALTER TYPE billingstatus RENAME TO billingstatus_new;
+
+CREATE TYPE billingstatus AS ENUM(
+    'free',
+    'early_payment',
+    'active',
+    'past_due',
+    'canceling',
+    'canceled'
+);
+
+ALTER TABLE billings
+ALTER COLUMN billing_status
+TYPE billingstatus
+USING billing_status::text::billingstatus;
+
+ALTER TABLE billings
+ALTER COLUMN billing_status SET DEFAULT 'free'::billingstatus;
+
+DROP TYPE billingstatus_new;
+
+ALTER TABLE billings
+ADD CONSTRAINT ck_billings_billing_status
+CHECK (billing_status::text = ANY (ARRAY[
+    'free'::character varying::text,
+    'early_payment'::character varying::text,
+    'active'::character varying::text,
+    'past_due'::character varying::text,
+    'canceling'::character varying::text,
+    'canceled'::character varying::text
+]));
+
+COMMENT ON COLUMN billings.billing_status IS
+'Billing status: free (無料トライアル), early_payment (早期支払い完了・無料期間中), active (課金中), past_due (支払い遅延), canceling (キャンセル予定), canceled (キャンセル済み)';
+
+COMMIT;

--- a/migrations/sql/q8r9s0t1u2v3_add_trial_expired_and_payment_failed_billing_status_upgrade.sql
+++ b/migrations/sql/q8r9s0t1u2v3_add_trial_expired_and_payment_failed_billing_status_upgrade.sql
@@ -1,0 +1,120 @@
+-- =====================================================
+-- Upgrade: add trial_expired/payment_failed billing statuses
+-- =====================================================
+-- Revision ID: q8r9s0t1u2v3
+-- Alembic file:
+--   migrations/versions/q8r9s0t1u2v3_add_trial_expired_and_payment_failed_billing_status.py
+--
+-- Current DB premise:
+--   ck_billings_billing_status currently allows:
+--   free / early_payment / active / past_due / canceling / canceled
+--
+-- Change:
+--   1. Drop current 6-value CHECK constraint.
+--   2. Recreate billingstatus enum with:
+--      free / early_payment / active / past_due / trial_expired /
+--      payment_failed / canceling / canceled
+--   3. Recreate ck_billings_billing_status with the same 8 values.
+-- =====================================================
+
+BEGIN;
+
+ALTER TABLE billings
+DROP CONSTRAINT IF EXISTS ck_billings_billing_status;
+
+ALTER TABLE billings
+ALTER COLUMN billing_status DROP DEFAULT;
+
+ALTER TYPE billingstatus RENAME TO billingstatus_old;
+
+CREATE TYPE billingstatus AS ENUM(
+    'free',
+    'early_payment',
+    'active',
+    'past_due',
+    'trial_expired',
+    'payment_failed',
+    'canceling',
+    'canceled'
+);
+
+ALTER TABLE billings
+ALTER COLUMN billing_status
+TYPE billingstatus
+USING billing_status::text::billingstatus;
+
+ALTER TABLE billings
+ALTER COLUMN billing_status SET DEFAULT 'free'::billingstatus;
+
+DROP TYPE billingstatus_old;
+
+ALTER TABLE billings
+ADD CONSTRAINT ck_billings_billing_status
+CHECK (billing_status::text = ANY (ARRAY[
+    'free'::character varying::text,
+    'early_payment'::character varying::text,
+    'active'::character varying::text,
+    'past_due'::character varying::text,
+    'trial_expired'::character varying::text,
+    'payment_failed'::character varying::text,
+    'canceling'::character varying::text,
+    'canceled'::character varying::text
+]));
+
+COMMENT ON COLUMN billings.billing_status IS
+'Billing status: free (無料トライアル), early_payment (早期支払い完了・無料期間中), active (課金中), past_due (互換用の支払い対応必要状態), trial_expired (無料期間終了・未課金), payment_failed (支払い失敗), canceling (キャンセル予定), canceled (キャンセル済み)';
+
+COMMIT;
+
+-- =====================================================
+-- Downgrade: remove trial_expired/payment_failed billing statuses
+-- =====================================================
+
+-- BEGIN;
+
+-- UPDATE billings
+-- SET billing_status = 'past_due'
+-- WHERE billing_status IN ('trial_expired', 'payment_failed');
+
+-- ALTER TABLE billings
+-- DROP CONSTRAINT IF EXISTS ck_billings_billing_status;
+
+-- ALTER TABLE billings
+-- ALTER COLUMN billing_status DROP DEFAULT;
+
+-- ALTER TYPE billingstatus RENAME TO billingstatus_new;
+
+-- CREATE TYPE billingstatus AS ENUM(
+--     'free',
+--     'early_payment',
+--     'active',
+--     'past_due',
+--     'canceling',
+--     'canceled'
+-- );
+
+-- ALTER TABLE billings
+-- ALTER COLUMN billing_status
+-- TYPE billingstatus
+-- USING billing_status::text::billingstatus;
+
+-- ALTER TABLE billings
+-- ALTER COLUMN billing_status SET DEFAULT 'free'::billingstatus;
+
+-- DROP TYPE billingstatus_new;
+
+-- ALTER TABLE billings
+-- ADD CONSTRAINT ck_billings_billing_status
+-- CHECK (billing_status::text = ANY (ARRAY[
+--     'free'::character varying::text,
+--     'early_payment'::character varying::text,
+--     'active'::character varying::text,
+--     'past_due'::character varying::text,
+--     'canceling'::character varying::text,
+--     'canceled'::character varying::text
+-- ]));
+
+-- COMMENT ON COLUMN billings.billing_status IS
+-- 'Billing status: free (無料トライアル), early_payment (早期支払い完了・無料期間中), active (課金中), past_due (支払い遅延), canceling (キャンセル予定), canceled (キャンセル済み)';
+
+-- COMMIT;

--- a/migrations/versions/q8r9s0t1u2v3_add_trial_expired_and_payment_failed_billing_status.py
+++ b/migrations/versions/q8r9s0t1u2v3_add_trial_expired_and_payment_failed_billing_status.py
@@ -1,0 +1,180 @@
+"""Add trial_expired and payment_failed billing statuses
+
+Revision ID: q8r9s0t1u2v3
+Revises: p7q8r9s0t1u2
+Create Date: 2026-06-18
+
+BillingStatus enumに以下を追加する。
+- trial_expired: trial終了後、未課金
+- payment_failed: 支払い失敗、または請求失敗
+
+本アプリの運用に合わせて、同内容の手動実行SQLを
+以下に分割して用意する。
+- `migrations/sql/q8r9s0t1u2v3_add_trial_expired_and_payment_failed_billing_status_confirm.sql`
+- `migrations/sql/q8r9s0t1u2v3_add_trial_expired_and_payment_failed_billing_status_upgrade.sql`
+- `migrations/sql/q8r9s0t1u2v3_add_trial_expired_and_payment_failed_billing_status_downgrade.sql`
+
+注意:
+- DBへの実反映はAlembicコマンドではなくSQLファイルを手動実行して行う。
+- このmigrationファイルは、手動実行SQLと同じ変更内容を残すための記録として作成する。
+- 現行DBでは `ck_billings_billing_status` が以下6値を許可している前提。
+  free / early_payment / active / past_due / canceling / canceled
+"""
+from typing import Sequence, Union
+
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision: str = 'q8r9s0t1u2v3'
+down_revision: Union[str, None] = 'p7q8r9s0t1u2'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+NEW_BILLING_STATUS_COMMENT = (
+    "Billing status: free (無料トライアル), "
+    "early_payment (早期支払い完了・無料期間中), "
+    "active (課金中), "
+    "past_due (互換用の支払い対応必要状態), "
+    "trial_expired (無料期間終了・未課金), "
+    "payment_failed (支払い失敗), "
+    "canceling (キャンセル予定), "
+    "canceled (キャンセル済み)"
+)
+
+OLD_BILLING_STATUS_COMMENT = (
+    "Billing status: free (無料トライアル), "
+    "early_payment (早期支払い完了・無料期間中), "
+    "active (課金中), "
+    "past_due (支払い遅延), "
+    "canceling (キャンセル予定), "
+    "canceled (キャンセル済み)"
+)
+
+
+def upgrade() -> None:
+    """BillingStatus enumにtrial_expired/payment_failedを追加する。"""
+
+    # 現行CHECK制約は6値のみ許可しているため、enum型変更前に削除する。
+    # 変更後はtrial_expired/payment_failedを含む8値のCHECK制約として再作成する。
+    op.execute("""
+        ALTER TABLE billings
+        DROP CONSTRAINT IF EXISTS ck_billings_billing_status
+    """)
+
+    op.execute("ALTER TABLE billings ALTER COLUMN billing_status DROP DEFAULT")
+
+    op.execute("ALTER TYPE billingstatus RENAME TO billingstatus_old")
+
+    op.execute("""
+        CREATE TYPE billingstatus AS ENUM(
+            'free',
+            'early_payment',
+            'active',
+            'past_due',
+            'trial_expired',
+            'payment_failed',
+            'canceling',
+            'canceled'
+        )
+    """)
+
+    op.execute("""
+        ALTER TABLE billings
+        ALTER COLUMN billing_status
+        TYPE billingstatus
+        USING billing_status::text::billingstatus
+    """)
+
+    op.execute("ALTER TABLE billings ALTER COLUMN billing_status SET DEFAULT 'free'::billingstatus")
+
+    op.execute("DROP TYPE billingstatus_old")
+
+    op.execute("""
+        ALTER TABLE billings
+        ADD CONSTRAINT ck_billings_billing_status
+        CHECK (billing_status::text = ANY (ARRAY[
+            'free'::character varying::text,
+            'early_payment'::character varying::text,
+            'active'::character varying::text,
+            'past_due'::character varying::text,
+            'trial_expired'::character varying::text,
+            'payment_failed'::character varying::text,
+            'canceling'::character varying::text,
+            'canceled'::character varying::text
+        ]))
+    """)
+
+    op.execute(f"""
+        COMMENT ON COLUMN billings.billing_status IS
+        '{NEW_BILLING_STATUS_COMMENT}'
+    """)
+
+
+def downgrade() -> None:
+    """
+    BillingStatus enumからtrial_expired/payment_failedを削除する。
+
+    互換性維持のため、既存のtrial_expired/payment_failedデータは
+    downgrade前にpast_dueへ戻す。
+    """
+
+    # downgrade後のCHECK制約ではtrial_expired/payment_failedを許可しないため、
+    # 先に後方互換用のpast_dueへ戻す。
+    op.execute("""
+        UPDATE billings
+        SET billing_status = 'past_due'
+        WHERE billing_status IN ('trial_expired', 'payment_failed')
+    """)
+
+    # 8値のCHECK制約を削除し、enum型を6値へ戻したあと、
+    # 現行DBと同じ6値のCHECK制約を再作成する。
+    op.execute("""
+        ALTER TABLE billings
+        DROP CONSTRAINT IF EXISTS ck_billings_billing_status
+    """)
+
+    op.execute("ALTER TABLE billings ALTER COLUMN billing_status DROP DEFAULT")
+
+    op.execute("ALTER TYPE billingstatus RENAME TO billingstatus_new")
+
+    op.execute("""
+        CREATE TYPE billingstatus AS ENUM(
+            'free',
+            'early_payment',
+            'active',
+            'past_due',
+            'canceling',
+            'canceled'
+        )
+    """)
+
+    op.execute("""
+        ALTER TABLE billings
+        ALTER COLUMN billing_status
+        TYPE billingstatus
+        USING billing_status::text::billingstatus
+    """)
+
+    op.execute("ALTER TABLE billings ALTER COLUMN billing_status SET DEFAULT 'free'::billingstatus")
+
+    op.execute("DROP TYPE billingstatus_new")
+
+    op.execute("""
+        ALTER TABLE billings
+        ADD CONSTRAINT ck_billings_billing_status
+        CHECK (billing_status::text = ANY (ARRAY[
+            'free'::character varying::text,
+            'early_payment'::character varying::text,
+            'active'::character varying::text,
+            'past_due'::character varying::text,
+            'canceling'::character varying::text,
+            'canceled'::character varying::text
+        ]))
+    """)
+
+    op.execute(f"""
+        COMMENT ON COLUMN billings.billing_status IS
+        '{OLD_BILLING_STATUS_COMMENT}'
+    """)

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,15 +1,22 @@
 [pytest]
 pythonpath = . k_back
 asyncio_mode = auto
-log_cli = true
+log_cli = false
 log_cli_level = WARNING
 # INFO, WARNING
 log_cli_format = %(asctime)s [%(levelname)8s] %(name)s - %(message)s
 log_cli_date_format = %Y-%m-%d %H:%M:%S
 log_file = tests.log
 # log_file_level = DEBUG
-# Display test session start/end with database cleanup messages
-addopts = -v --tb=short -s
+# Keep stdout/stderr captured unless a test fails.
+addopts = --tb=short
+filterwarnings =
+    ignore:'crypt' is deprecated.*:DeprecationWarning
+    ignore:Please use `import python_multipart` instead.:PendingDeprecationWarning
+    ignore:.*deprecated - use.*:DeprecationWarning:httplib2.auth
+    ignore:.*on_event is deprecated.*:DeprecationWarning
+    ignore::DeprecationWarning:fastapi.applications
+    ignore::DeprecationWarning:app.main
 
 # === カバレッジ設定 ===
 # カバレッジ測定を有効にする場合は以下のコマンドを使用:

--- a/tests/api/test_billing.py
+++ b/tests/api/test_billing.py
@@ -3,6 +3,7 @@ Billing API エンドポイントのテスト
 """
 from datetime import datetime, timedelta, timezone
 from unittest.mock import patch, MagicMock, AsyncMock
+from uuid import uuid4
 import pytest
 from httpx import AsyncClient
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -97,6 +98,86 @@ async def test_get_billing_status_past_due(
     assert response.status_code == 200
     data = response.json()
     assert data["billing_status"] == "past_due"
+
+
+async def test_get_billing_status_expired_free_updates_to_trial_expired(
+    async_client: AsyncClient,
+    db_session: AsyncSession,
+    employee_user_factory
+) -> None:
+    """
+    期限切れfreeはCheckout遷移を待たず、ステータス取得時にtrial_expiredへ補正される。
+    """
+    staff = await employee_user_factory()
+    office_id = staff.office_associations[0].office_id
+
+    access_token_expires = timedelta(minutes=settings.ACCESS_TOKEN_EXPIRE_MINUTES)
+    access_token = create_access_token(str(staff.id), access_token_expires)
+
+    expired_trial_end = datetime.now(timezone.utc) - timedelta(days=1)
+    billing_data = BillingCreate(
+        office_id=office_id,
+        billing_status=BillingStatus.free,
+        trial_start_date=expired_trial_end - timedelta(days=180),
+        trial_end_date=expired_trial_end,
+        current_plan_amount=6000
+    )
+    billing = await crud.billing.create(db=db_session, obj_in=billing_data)
+    await db_session.commit()
+
+    response = await async_client.get(
+        "/api/v1/billing/status",
+        headers={"Authorization": f"Bearer {access_token}"}
+    )
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["billing_status"] == "trial_expired"
+
+    billing_after = await crud.billing.get(db=db_session, id=billing.id)
+    assert billing_after.billing_status == BillingStatus.trial_expired
+
+
+async def test_get_billing_status_expired_early_payment_updates_to_active(
+    async_client: AsyncClient,
+    db_session: AsyncSession,
+    employee_user_factory
+) -> None:
+    """
+    期限切れearly_paymentはバッチ実行を待たず、ステータス取得時にactiveへ補正される。
+    """
+    staff = await employee_user_factory()
+    office_id = staff.office_associations[0].office_id
+
+    access_token_expires = timedelta(minutes=settings.ACCESS_TOKEN_EXPIRE_MINUTES)
+    access_token = create_access_token(str(staff.id), access_token_expires)
+
+    expired_trial_end = datetime.now(timezone.utc) - timedelta(days=1)
+    billing_data = BillingCreate(
+        office_id=office_id,
+        billing_status=BillingStatus.early_payment,
+        stripe_customer_id=f"cus_test_expired_early_{uuid4().hex[:8]}",
+        stripe_subscription_id=f"sub_test_expired_early_{uuid4().hex[:8]}",
+        trial_start_date=expired_trial_end - timedelta(days=180),
+        trial_end_date=expired_trial_end,
+        subscription_start_date=datetime.now(timezone.utc),
+        last_payment_date=datetime.now(timezone.utc),
+        current_plan_amount=6000
+    )
+    billing = await crud.billing.create(db=db_session, obj_in=billing_data)
+    await db_session.commit()
+
+    response = await async_client.get(
+        "/api/v1/billing/status",
+        headers={"Authorization": f"Bearer {access_token}"}
+    )
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["billing_status"] == "active"
+
+    billing_after = await crud.billing.get(db=db_session, id=billing.id)
+    assert billing_after.billing_status == BillingStatus.active
 
 
 async def test_require_active_billing_restriction(
@@ -281,6 +362,412 @@ async def test_create_checkout_session_includes_metadata(
     # automatic_taxが有効化されることを確認
     assert 'automatic_tax' in call_kwargs
     assert call_kwargs['automatic_tax']['enabled'] is True
+
+
+async def test_create_checkout_session_expired_free_without_customer_recovers_to_trial_expired(
+    async_client: AsyncClient,
+    db_session: AsyncSession,
+    employee_user_factory,
+    mocker: MagicMock
+) -> None:
+    """
+    期限切れfreeかつstripe_customer_id未設定の事業所でもCheckoutが500にならず、trial_expiredへ補正されることを確認。
+    """
+    mocker.patch('app.api.v1.endpoints.billing.settings.STRIPE_SECRET_KEY', 'sk_test_12345')
+    mocker.patch('app.api.v1.endpoints.billing.settings.STRIPE_PRICE_ID', 'price_test_12345')
+
+    unique_id = uuid4().hex
+    customer_id = f"cus_expired_free_{unique_id}"
+    checkout_session_id = f"cs_expired_free_{unique_id}"
+
+    mock_customer_create = mocker.patch('stripe.Customer.create')
+    mock_customer_create.return_value = MagicMock(id=customer_id)
+
+    mock_session_create = mocker.patch('stripe.checkout.Session.create')
+    mock_session_create.return_value = MagicMock(
+        id=checkout_session_id,
+        url='https://checkout.stripe.com/expired-free'
+    )
+
+    staff = await employee_user_factory(role=StaffRole.owner)
+    office_id = staff.office_associations[0].office_id
+
+    access_token_expires = timedelta(minutes=settings.ACCESS_TOKEN_EXPIRE_MINUTES)
+    access_token = create_access_token(str(staff.id), access_token_expires)
+
+    expired_trial_end = datetime.now(timezone.utc) - timedelta(days=10)
+    billing_data = BillingCreate(
+        office_id=office_id,
+        billing_status=BillingStatus.free,
+        trial_start_date=expired_trial_end - timedelta(days=180),
+        trial_end_date=expired_trial_end,
+        current_plan_amount=6000
+    )
+    billing = await crud.billing.create(db=db_session, obj_in=billing_data)
+    await db_session.commit()
+    assert billing.stripe_customer_id is None
+
+    response = await async_client.post(
+        "/api/v1/billing/create-checkout-session",
+        headers={"Authorization": f"Bearer {access_token}"}
+    )
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["session_id"] == checkout_session_id
+    assert data["url"] == "https://checkout.stripe.com/expired-free"
+
+    mock_session_create.assert_called_once()
+    subscription_data = mock_session_create.call_args.kwargs["subscription_data"]
+    assert "trial_end" not in subscription_data
+
+    billing_after = await crud.billing.get(db=db_session, id=billing.id)
+    assert billing_after.billing_status == BillingStatus.trial_expired
+    assert billing_after.stripe_customer_id == customer_id
+
+
+async def test_create_checkout_session_expired_free_with_existing_customer_recovers_to_trial_expired(
+    async_client: AsyncClient,
+    db_session: AsyncSession,
+    employee_user_factory,
+    mocker: MagicMock
+) -> None:
+    """
+    既存Customerありの期限切れfree事業所でもCheckout前にtrial_expiredへ補正されることを確認。
+    """
+    mocker.patch('app.api.v1.endpoints.billing.settings.STRIPE_SECRET_KEY', 'sk_test_12345')
+    mocker.patch('app.api.v1.endpoints.billing.settings.STRIPE_PRICE_ID', 'price_test_12345')
+
+    unique_id = uuid4().hex
+    customer_id = f"cus_existing_expired_free_{unique_id}"
+    checkout_session_id = f"cs_existing_expired_free_{unique_id}"
+
+    mock_session_create = mocker.patch('stripe.checkout.Session.create')
+    mock_session_create.return_value = MagicMock(
+        id=checkout_session_id,
+        url='https://checkout.stripe.com/existing-expired-free'
+    )
+
+    staff = await employee_user_factory(role=StaffRole.owner)
+    office_id = staff.office_associations[0].office_id
+
+    access_token_expires = timedelta(minutes=settings.ACCESS_TOKEN_EXPIRE_MINUTES)
+    access_token = create_access_token(str(staff.id), access_token_expires)
+
+    expired_trial_end = datetime.now(timezone.utc) - timedelta(days=10)
+    billing_data = BillingCreate(
+        office_id=office_id,
+        billing_status=BillingStatus.free,
+        stripe_customer_id=customer_id,
+        trial_start_date=expired_trial_end - timedelta(days=180),
+        trial_end_date=expired_trial_end,
+        current_plan_amount=6000
+    )
+    billing = await crud.billing.create(db=db_session, obj_in=billing_data)
+    await db_session.commit()
+
+    response = await async_client.post(
+        "/api/v1/billing/create-checkout-session",
+        headers={"Authorization": f"Bearer {access_token}"}
+    )
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["session_id"] == checkout_session_id
+    assert data["url"] == "https://checkout.stripe.com/existing-expired-free"
+
+    mock_session_create.assert_called_once()
+    call_kwargs = mock_session_create.call_args.kwargs
+    assert call_kwargs["customer"] == customer_id
+    assert "trial_end" not in call_kwargs["subscription_data"]
+
+    billing_after = await crud.billing.get(db=db_session, id=billing.id)
+    assert billing_after.billing_status == BillingStatus.trial_expired
+    assert billing_after.stripe_customer_id == customer_id
+
+
+async def test_create_checkout_session_failure_rolls_back_new_customer_and_status_correction(
+    async_client: AsyncClient,
+    db_session: AsyncSession,
+    employee_user_factory,
+    mocker: MagicMock
+) -> None:
+    """
+    新規Customer作成後にCheckout作成が失敗した場合、Customer ID保存と期限切れ補正がrollbackされる。
+    """
+    mocker.patch('app.api.v1.endpoints.billing.settings.STRIPE_SECRET_KEY', 'sk_test_12345')
+    mocker.patch('app.api.v1.endpoints.billing.settings.STRIPE_PRICE_ID', 'price_test_12345')
+
+    unique_id = uuid4().hex
+    customer_id = f"cus_checkout_failure_{unique_id}"
+
+    mock_customer_create = mocker.patch('stripe.Customer.create')
+    mock_customer_create.return_value = MagicMock(id=customer_id)
+
+    mock_session_create = mocker.patch('stripe.checkout.Session.create')
+    mock_session_create.side_effect = Exception("checkout session failed")
+
+    staff = await employee_user_factory(role=StaffRole.owner)
+    office_id = staff.office_associations[0].office_id
+
+    access_token_expires = timedelta(minutes=settings.ACCESS_TOKEN_EXPIRE_MINUTES)
+    access_token = create_access_token(str(staff.id), access_token_expires)
+
+    expired_trial_end = datetime.now(timezone.utc) - timedelta(days=10)
+    billing_data = BillingCreate(
+        office_id=office_id,
+        billing_status=BillingStatus.free,
+        trial_start_date=expired_trial_end - timedelta(days=180),
+        trial_end_date=expired_trial_end,
+        current_plan_amount=6000
+    )
+    billing = await crud.billing.create(db=db_session, obj_in=billing_data)
+    billing_id = billing.id
+    await db_session.commit()
+
+    response = await async_client.post(
+        "/api/v1/billing/create-checkout-session",
+        headers={"Authorization": f"Bearer {access_token}"}
+    )
+
+    assert response.status_code == 500
+    mock_customer_create.assert_called_once()
+    mock_session_create.assert_called_once()
+
+    db_session.expire_all()
+    billing_after = await crud.billing.get(db=db_session, id=billing_id)
+    assert billing_after.billing_status == BillingStatus.free
+    assert billing_after.stripe_customer_id is None
+
+
+async def test_create_checkout_session_failure_rolls_back_existing_customer_status_correction(
+    async_client: AsyncClient,
+    db_session: AsyncSession,
+    employee_user_factory,
+    mocker: MagicMock
+) -> None:
+    """
+    既存CustomerのCheckout作成が失敗した場合、期限切れ補正だけがrollbackされ、既存Customer IDは維持される。
+    """
+    mocker.patch('app.api.v1.endpoints.billing.settings.STRIPE_SECRET_KEY', 'sk_test_12345')
+    mocker.patch('app.api.v1.endpoints.billing.settings.STRIPE_PRICE_ID', 'price_test_12345')
+
+    unique_id = uuid4().hex
+    customer_id = f"cus_existing_checkout_failure_{unique_id}"
+
+    mock_session_create = mocker.patch('stripe.checkout.Session.create')
+    mock_session_create.side_effect = Exception("checkout session failed")
+
+    staff = await employee_user_factory(role=StaffRole.owner)
+    office_id = staff.office_associations[0].office_id
+
+    access_token_expires = timedelta(minutes=settings.ACCESS_TOKEN_EXPIRE_MINUTES)
+    access_token = create_access_token(str(staff.id), access_token_expires)
+
+    expired_trial_end = datetime.now(timezone.utc) - timedelta(days=10)
+    billing_data = BillingCreate(
+        office_id=office_id,
+        billing_status=BillingStatus.free,
+        stripe_customer_id=customer_id,
+        trial_start_date=expired_trial_end - timedelta(days=180),
+        trial_end_date=expired_trial_end,
+        current_plan_amount=6000
+    )
+    billing = await crud.billing.create(db=db_session, obj_in=billing_data)
+    billing_id = billing.id
+    await db_session.commit()
+
+    response = await async_client.post(
+        "/api/v1/billing/create-checkout-session",
+        headers={"Authorization": f"Bearer {access_token}"}
+    )
+
+    assert response.status_code == 500
+    mock_session_create.assert_called_once()
+
+    db_session.expire_all()
+    billing_after = await crud.billing.get(db=db_session, id=billing_id)
+    assert billing_after.billing_status == BillingStatus.free
+    assert billing_after.stripe_customer_id == customer_id
+
+
+async def test_create_checkout_session_existing_customer_in_trial_includes_trial_end(
+    async_client: AsyncClient,
+    db_session: AsyncSession,
+    employee_user_factory,
+    mocker: MagicMock
+) -> None:
+    """
+    既存Customerあり、trial中freeの事業所では従来どおりtrial_endをStripeに渡すことを確認。
+    """
+    mocker.patch('app.api.v1.endpoints.billing.settings.STRIPE_SECRET_KEY', 'sk_test_12345')
+    mocker.patch('app.api.v1.endpoints.billing.settings.STRIPE_PRICE_ID', 'price_test_12345')
+
+    unique_id = uuid4().hex
+    customer_id = f"cus_existing_trial_{unique_id}"
+    checkout_session_id = f"cs_existing_trial_{unique_id}"
+
+    mock_session_create = mocker.patch('stripe.checkout.Session.create')
+    mock_session_create.return_value = MagicMock(
+        id=checkout_session_id,
+        url='https://checkout.stripe.com/existing-trial'
+    )
+
+    staff = await employee_user_factory(role=StaffRole.owner)
+    office_id = staff.office_associations[0].office_id
+
+    access_token_expires = timedelta(minutes=settings.ACCESS_TOKEN_EXPIRE_MINUTES)
+    access_token = create_access_token(str(staff.id), access_token_expires)
+
+    future_trial_end = datetime.now(timezone.utc) + timedelta(days=30)
+    billing_data = BillingCreate(
+        office_id=office_id,
+        billing_status=BillingStatus.free,
+        stripe_customer_id=customer_id,
+        trial_start_date=future_trial_end - timedelta(days=150),
+        trial_end_date=future_trial_end,
+        current_plan_amount=6000
+    )
+    billing = await crud.billing.create(db=db_session, obj_in=billing_data)
+    await db_session.commit()
+
+    response = await async_client.post(
+        "/api/v1/billing/create-checkout-session",
+        headers={"Authorization": f"Bearer {access_token}"}
+    )
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["session_id"] == checkout_session_id
+    assert data["url"] == "https://checkout.stripe.com/existing-trial"
+
+    mock_session_create.assert_called_once()
+    call_kwargs = mock_session_create.call_args.kwargs
+    assert call_kwargs["customer"] == customer_id
+    assert call_kwargs["subscription_data"]["trial_end"] == int(future_trial_end.timestamp())
+
+    billing_after = await crud.billing.get(db=db_session, id=billing.id)
+    assert billing_after.billing_status == BillingStatus.free
+
+
+async def test_create_checkout_session_past_due_existing_customer_excludes_trial_end(
+    async_client: AsyncClient,
+    db_session: AsyncSession,
+    employee_user_factory,
+    mocker: MagicMock
+) -> None:
+    """
+    既存Customerあり、past_dueの事業所では過去trial_endをStripeに渡さないことを確認。
+    """
+    mocker.patch('app.api.v1.endpoints.billing.settings.STRIPE_SECRET_KEY', 'sk_test_12345')
+    mocker.patch('app.api.v1.endpoints.billing.settings.STRIPE_PRICE_ID', 'price_test_12345')
+
+    unique_id = uuid4().hex
+    customer_id = f"cus_existing_past_due_{unique_id}"
+    checkout_session_id = f"cs_existing_past_due_{unique_id}"
+
+    mock_session_create = mocker.patch('stripe.checkout.Session.create')
+    mock_session_create.return_value = MagicMock(
+        id=checkout_session_id,
+        url='https://checkout.stripe.com/existing-past-due'
+    )
+
+    staff = await employee_user_factory(role=StaffRole.owner)
+    office_id = staff.office_associations[0].office_id
+
+    access_token_expires = timedelta(minutes=settings.ACCESS_TOKEN_EXPIRE_MINUTES)
+    access_token = create_access_token(str(staff.id), access_token_expires)
+
+    expired_trial_end = datetime.now(timezone.utc) - timedelta(days=10)
+    billing_data = BillingCreate(
+        office_id=office_id,
+        billing_status=BillingStatus.past_due,
+        stripe_customer_id=customer_id,
+        trial_start_date=expired_trial_end - timedelta(days=180),
+        trial_end_date=expired_trial_end,
+        current_plan_amount=6000
+    )
+    billing = await crud.billing.create(db=db_session, obj_in=billing_data)
+    await db_session.commit()
+
+    response = await async_client.post(
+        "/api/v1/billing/create-checkout-session",
+        headers={"Authorization": f"Bearer {access_token}"}
+    )
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["session_id"] == checkout_session_id
+    assert data["url"] == "https://checkout.stripe.com/existing-past-due"
+
+    mock_session_create.assert_called_once()
+    call_kwargs = mock_session_create.call_args.kwargs
+    assert call_kwargs["customer"] == customer_id
+    assert "trial_end" not in call_kwargs["subscription_data"]
+
+    billing_after = await crud.billing.get(db=db_session, id=billing.id)
+    assert billing_after.billing_status == BillingStatus.past_due
+
+
+async def test_create_checkout_session_existing_customer_with_naive_trial_end(
+    async_client: AsyncClient,
+    db_session: AsyncSession,
+    employee_user_factory,
+    mocker: MagicMock
+) -> None:
+    """
+    既存Customerあり、naive datetimeのtrial_end_dateでも比較エラーで500にならないことを確認。
+    """
+    mocker.patch('app.api.v1.endpoints.billing.settings.STRIPE_SECRET_KEY', 'sk_test_12345')
+    mocker.patch('app.api.v1.endpoints.billing.settings.STRIPE_PRICE_ID', 'price_test_12345')
+
+    unique_id = uuid4().hex
+    customer_id = f"cus_existing_naive_{unique_id}"
+    checkout_session_id = f"cs_existing_naive_{unique_id}"
+
+    mock_session_create = mocker.patch('stripe.checkout.Session.create')
+    mock_session_create.return_value = MagicMock(
+        id=checkout_session_id,
+        url='https://checkout.stripe.com/existing-naive'
+    )
+
+    staff = await employee_user_factory(role=StaffRole.owner)
+    office_id = staff.office_associations[0].office_id
+
+    access_token_expires = timedelta(minutes=settings.ACCESS_TOKEN_EXPIRE_MINUTES)
+    access_token = create_access_token(str(staff.id), access_token_expires)
+
+    naive_trial_end = datetime.now() + timedelta(days=30)
+    billing_data = BillingCreate(
+        office_id=office_id,
+        billing_status=BillingStatus.free,
+        stripe_customer_id=customer_id,
+        trial_start_date=naive_trial_end - timedelta(days=150),
+        trial_end_date=naive_trial_end,
+        current_plan_amount=6000
+    )
+    billing = await crud.billing.create(db=db_session, obj_in=billing_data)
+    await db_session.commit()
+
+    response = await async_client.post(
+        "/api/v1/billing/create-checkout-session",
+        headers={"Authorization": f"Bearer {access_token}"}
+    )
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["session_id"] == checkout_session_id
+    assert data["url"] == "https://checkout.stripe.com/existing-naive"
+
+    mock_session_create.assert_called_once()
+    call_kwargs = mock_session_create.call_args.kwargs
+    assert call_kwargs["customer"] == customer_id
+    assert call_kwargs["subscription_data"]["trial_end"] == int(
+        naive_trial_end.replace(tzinfo=timezone.utc).timestamp()
+    )
+
+    billing_after = await crud.billing.get(db=db_session, id=billing.id)
+    assert billing_after.billing_status == BillingStatus.free
 
 
 @patch('stripe.Webhook.construct_event')

--- a/tests/api/v1/test_assessment.py
+++ b/tests/api/v1/test_assessment.py
@@ -177,11 +177,6 @@ class TestGetAllAssessmentData:
         self, async_client: AsyncClient, db_session: AsyncSession
     ):
         """401: 未認証の場合、エラーを返す"""
-        print("\n" + "="*80)
-        print("=== TEST: test_get_all_assessment_data_unauthorized START ===")
-        print("NOTE: This test does NOT use setup_recipient to avoid dependency override")
-        logger.info("=== test_get_all_assessment_data_unauthorized start ===")
-
         # 利用者だけを作成（オーバーライドなし）
         recipient = WelfareRecipient(
             last_name="テスト",
@@ -195,20 +190,9 @@ class TestGetAllAssessmentData:
         await db_session.flush()
         await db_session.refresh(recipient)
 
-        print(f"Testing with recipient_id: {recipient.id}")
-        print("Sending request WITHOUT authorization headers (no override)")
-        logger.info(f"Testing with recipient_id: {recipient.id}")
-        logger.info("Sending request WITHOUT authorization headers")
-
         response = await async_client.get(
             f"{settings.API_V1_STR}/recipients/{recipient.id}/assessment",
         )
-
-        print(f"Response status code: {response.status_code}")
-        print(f"Response body: {response.text}")
-        print("="*80 + "\n")
-        logger.info(f"Response status code: {response.status_code}")
-        logger.info(f"Response body: {response.text}")
 
         assert response.status_code == status.HTTP_401_UNAUTHORIZED
 

--- a/tests/api/v1/test_office.py
+++ b/tests/api/v1/test_office.py
@@ -65,13 +65,6 @@ class TestSetupOffice:
         # Act
         # この時点ではエンドポイントが存在しないため404が返るが、実装後は200になることを期待
         response = await async_client.post("/api/v1/offices/setup", json=payload, headers=headers)
-        print("Status Code:", response.status_code)
-        try:
-            print("Response JSON:", response.json())
-        except Exception as e:
-            print("Response Text:", response.text)
-            print("JSON Decode Error:", e)
-
 
         # Assert: レスポンスの検証
         assert response.status_code == 201
@@ -79,7 +72,6 @@ class TestSetupOffice:
         assert data["name"] == payload["name"]
         assert data["office_type"] == payload["office_type"]
         assert "id" in data
-        print(f"Response data: {data}")
 
         # Assert: DBの状態の検証
         # 1. Officeが作成されたか

--- a/tests/api/v1/test_plan_deliverables.py
+++ b/tests/api/v1/test_plan_deliverables.py
@@ -5,12 +5,8 @@ from sqlalchemy import select
 from sqlalchemy.orm import selectinload
 from datetime import date, datetime
 import io
-import logging
 import boto3
 from moto import mock_aws
-
-logging.basicConfig()
-logging.getLogger('sqlalchemy.engine').setLevel(logging.WARNING)
 
 from app.models.welfare_recipient import WelfareRecipient, OfficeWelfareRecipient
 from app.models.support_plan_cycle import SupportPlanCycle, SupportPlanStatus, PlanDeliverable
@@ -55,11 +51,6 @@ def s3_mock(aws_credentials):
         bucket_name = "test-plan-deliverables-bucket"
         s3_client.create_bucket(Bucket=bucket_name)
 
-        # バケットが作成されたことを確認
-        buckets = s3_client.list_buckets()
-        print(f"\n=== S3 Mock Setup ===")
-        print(f"DEBUG: Created buckets: {[b['Name'] for b in buckets['Buckets']]}")
-
         yield s3_client
 
 
@@ -77,7 +68,6 @@ async def test_upload_assessment_pdf(
     アセスメントPDFのアップロードが正常に完了することを確認
     """
     # S3アップロード関数をモック
-    from unittest.mock import AsyncMock
     async def mock_upload_file(file, object_name: str):
         """S3アップロードをモック"""
         return f"s3://test-plan-deliverables-bucket/{object_name}"
@@ -86,24 +76,10 @@ async def test_upload_assessment_pdf(
     monkeypatch.setattr(storage, "upload_file", mock_upload_file)
 
     # 1. テストデータの準備
-    print(f"\n=== DEBUG: Test data preparation ===")
-    print(f"DEBUG: test_admin_user.id = {test_admin_user.id}")
-    print(f"DEBUG: db_session object id (test data prep) = {id(db_session)}")
-
     office = await office_factory(creator=test_admin_user)
-    print(f"DEBUG: office.id = {office.id}")
 
     db_session.add(OfficeStaff(staff_id=test_admin_user.id, office_id=office.id, is_primary=True))
     await db_session.flush()  # OfficeStaffを先にflush
-
-    # OfficeStaffが保存されたか確認
-    office_staff_check = await db_session.execute(
-        select(OfficeStaff).where(OfficeStaff.staff_id == test_admin_user.id)
-    )
-    saved_office_staff = office_staff_check.scalars().all()
-    print(f"DEBUG: OfficeStaff records saved = {len(saved_office_staff)}")
-    for idx, os in enumerate(saved_office_staff):
-        print(f"DEBUG: OfficeStaff[{idx}].staff_id = {os.staff_id}, office_id = {os.office_id}")
 
     recipient = WelfareRecipient(first_name="テスト", last_name="太郎", first_name_furigana="テスト", last_name_furigana="タロウ", birth_day=date(1990, 1, 1), gender=GenderType.male)
     db_session.add(recipient)
@@ -116,92 +92,14 @@ async def test_upload_assessment_pdf(
     statuses = [SupportPlanStatus(plan_cycle_id=cycle.id, welfare_recipient_id=recipient.id, office_id=office.id, step_type=s, is_latest_status=(s==SupportPlanStep.assessment)) for s in [SupportPlanStep.assessment, SupportPlanStep.draft_plan, SupportPlanStep.staff_meeting, SupportPlanStep.final_plan_signed]]
     db_session.add_all(statuses)
     await db_session.commit()
-    print(f"=== DEBUG: Test data preparation complete ===\n")
 
     # 2. 依存関係のオーバーライド（get_current_userのみ）
     async def override_get_current_user_with_relations():
-        print(f"\n=== DEBUG test_upload_assessment_pdf: override_get_current_user_with_relations called ===")
-        print(f"DEBUG: test_admin_user.id = {test_admin_user.id}")
-        print(f"DEBUG: db_session object id = {id(db_session)}")
-
-        # SQLAlchemyのSQLログを一時的に有効化
-        import logging
-        logging.basicConfig()
-        logging.getLogger('sqlalchemy.engine').setLevel(logging.INFO)
-
-        # SQL レベルでの確認: OfficeStaff が存在するか生SQLで確認
-        from sqlalchemy import text
-        print("\n--- Raw SQL Query ---")
-        raw_sql_result = await db_session.execute(
-            text("SELECT id, staff_id, office_id, is_primary FROM office_staffs WHERE staff_id = :staff_id"),
-            {"staff_id": str(test_admin_user.id)}
-        )
-        raw_rows = raw_sql_result.fetchall()
-        print(f"DEBUG: Raw SQL - OfficeStaff records = {len(raw_rows)}")
-        for idx, row in enumerate(raw_rows):
-            print(f"DEBUG: Raw SQL - OfficeStaff[{idx}]: id={row[0]}, staff_id={row[1]}, office_id={row[2]}, is_primary={row[3]}")
-
-        # OfficeStaffを直接クエリしてみる
-        print("\n--- Direct OfficeStaff Query ---")
-        office_staff_stmt = select(OfficeStaff).where(OfficeStaff.staff_id == test_admin_user.id)
-        office_staff_result = await db_session.execute(office_staff_stmt)
-        office_staff_records = office_staff_result.scalars().all()
-        print(f"DEBUG: Direct OfficeStaff query - records found = {len(office_staff_records)}")
-        for idx, os in enumerate(office_staff_records):
-            print(f"DEBUG: OfficeStaff[{idx}]: id={os.id}, staff_id={os.staff_id}, office_id={os.office_id}")
-            # Staffオブジェクトにアクセスしてみる
-            try:
-                print(f"DEBUG: OfficeStaff[{idx}].staff = {os.staff}")
-                print(f"DEBUG: OfficeStaff[{idx}].staff.id = {os.staff.id if os.staff else None}")
-            except Exception as e:
-                print(f"DEBUG: Error accessing OfficeStaff[{idx}].staff: {e}")
-
-        # selectinloadなしで取得してみる
-        print("\n--- Staff Query Without selectinload ---")
-        stmt_no_load = select(Staff).where(Staff.id == test_admin_user.id)
-        result_no_load = await db_session.execute(stmt_no_load)
-        user_no_load = result_no_load.scalars().first()
-        print(f"DEBUG: Without selectinload - user found = {user_no_load is not None}")
-        if user_no_load:
-            print(f"DEBUG: user_no_load object state: {user_no_load.__dict__}")
-            try:
-                print(f"DEBUG: Without selectinload - office_associations length = {len(user_no_load.office_associations)}")
-            except Exception as e:
-                print(f"DEBUG: Without selectinload - Error accessing office_associations: {type(e).__name__}: {e}")
-
-        # キャッシュをバイパスして強制的にDBから再ロード
-        print("\n--- Staff Query With selectinload (populate_existing=True) ---")
         stmt = select(Staff).where(Staff.id == test_admin_user.id).options(
             selectinload(Staff.office_associations).selectinload(OfficeStaff.office)
         ).execution_options(populate_existing=True)
         result = await db_session.execute(stmt)
-        user = result.scalars().first()
-
-        print(f"DEBUG: With selectinload - user found = {user is not None}")
-        if user:
-            print(f"DEBUG: user.id = {user.id}")
-            print(f"DEBUG: user object state: {user.__dict__}")
-            print(f"DEBUG: user.office_associations = {user.office_associations}")
-            print(f"DEBUG: len(office_associations) = {len(user.office_associations)}")
-            for idx, assoc in enumerate(user.office_associations):
-                print(f"DEBUG: association[{idx}].staff_id = {assoc.staff_id}")
-                print(f"DEBUG: association[{idx}].office_id = {assoc.office_id}")
-                print(f"DEBUG: association[{idx}].office = {assoc.office}")
-                if assoc.office:
-                    print(f"DEBUG: association[{idx}].office.id = {assoc.office.id}")
-                    print(f"DEBUG: association[{idx}].office.name = {assoc.office.name}")
-
-        # リレーションシップのメタデータを確認
-        print("\n--- Relationship Metadata ---")
-        print(f"DEBUG: Staff.office_associations.property = {Staff.office_associations.property}")
-        print(f"DEBUG: Staff.office_associations.property.mapper = {Staff.office_associations.property.mapper}")
-
-        print(f"=== DEBUG END ===\n")
-
-        # SQLログを元に戻す
-        logging.getLogger('sqlalchemy.engine').setLevel(logging.WARNING)
-
-        return user
+        return result.scalars().first()
 
     app.dependency_overrides[get_current_user] = override_get_current_user_with_relations
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -50,10 +50,11 @@ async def safe_cleanup_test_database(engine: AsyncEngine):
         engine: データベースエンジン
     """
     from tests.utils.safe_cleanup import SafeTestDataCleanup
+    verbose_cleanup = os.getenv("PYTEST_VERBOSE_CLEANUP") == "1"
 
     # テスト環境であることを確認
     if not SafeTestDataCleanup.verify_test_environment():
-        print("⚠️  Not in test environment - skipping cleanup")
+        logger.warning("Not in test environment - skipping cleanup")
         return
 
     async with engine.connect() as connection:
@@ -74,13 +75,18 @@ async def safe_cleanup_test_database(engine: AsyncEngine):
 
             if result:
                 total = sum(result.values())
-                print(f"  🧹 Deleted {total} factory-generated records:")
-                for table, count in sorted(result.items(), key=lambda x: x[1], reverse=True):
-                    print(f"    - {table}: {count}")
-            else:
-                print("  ✓ No factory-generated data found")
+                if verbose_cleanup:
+                    logger.info(
+                        "Deleted %s factory-generated records: %s",
+                        total,
+                        dict(sorted(result.items(), key=lambda x: x[1], reverse=True)),
+                    )
+                else:
+                    logger.info("Deleted %s factory-generated records", total)
+            elif verbose_cleanup:
+                logger.info("No factory-generated data found")
         except Exception as e:
-            print(f"  ❌ Safe cleanup failed: {e}")
+            logger.error("Safe cleanup failed: %s", e)
             await transaction.rollback()
             raise
         finally:
@@ -123,30 +129,23 @@ async def cleanup_database_session():
                 return "unknown"
 
         branch_name = get_db_branch_name(DATABASE_URL)
-        print("\n" + "=" * 80)
-        print("🔍 DATABASE CONNECTION INFO (cleanup_database_session)")
-        print("=" * 80)
-        print(f"  TEST_DATABASE_URL set: {'Yes' if TEST_DATABASE_URL_VAR else 'No'}")
-        print(f"  DATABASE_URL set: {'Yes' if DATABASE_URL_VAR else 'No'}")
-        print(f"  Using: {'TEST_DATABASE_URL' if TEST_DATABASE_URL_VAR else 'DATABASE_URL (FALLBACK)'}")
-        print(f"  Database branch: {branch_name}")
-        if TEST_DATABASE_URL_VAR:
-            print(f"  Connection string: {DATABASE_URL[:50]}...")
-        else:
-            print(f"  ⚠️  WARNING: TEST_DATABASE_URL not set, falling back to DATABASE_URL!")
-        print("=" * 80)
+        if os.getenv("PYTEST_VERBOSE_CLEANUP") == "1":
+            logger.info(
+                "Test DB: using=%s branch=%s test_url_set=%s database_url_set=%s",
+                "TEST_DATABASE_URL" if TEST_DATABASE_URL_VAR else "DATABASE_URL",
+                branch_name,
+                bool(TEST_DATABASE_URL_VAR),
+                bool(DATABASE_URL_VAR),
+            )
+        elif not TEST_DATABASE_URL_VAR:
+            logger.warning("TEST_DATABASE_URL not set; falling back to DATABASE_URL for tests")
 
         temp_engine = create_async_engine(DATABASE_URL, echo=False)
 
         try:
-            print("\n" + "=" * 60)
-            print("🧪 Starting test session - safe cleanup...")
-            print("=" * 60)
             await safe_cleanup_test_database(temp_engine)
-            print("✅ Pre-test cleanup completed")
-            print("=" * 60 + "\n")
         except Exception as e:
-            print(f"⚠️  Pre-test safe cleanup failed: {e}")
+            logger.warning("Pre-test safe cleanup failed: %s", e)
         finally:
             await temp_engine.dispose()
 
@@ -158,14 +157,9 @@ async def cleanup_database_session():
         temp_engine = create_async_engine(DATABASE_URL, echo=False)
 
         try:
-            print("\n" + "=" * 60)
-            print("🧪 Test session completed - safe cleanup...")
-            print("=" * 60)
             await safe_cleanup_test_database(temp_engine)
-            print("✅ Post-test cleanup completed")
-            print("=" * 60 + "\n")
         except Exception as e:
-            print(f"⚠️  Post-test safe cleanup failed: {e}")
+            logger.warning("Post-test safe cleanup failed: %s", e)
         finally:
             await temp_engine.dispose()
 
@@ -1035,20 +1029,16 @@ async def setup_recipient(
     from sqlalchemy import select
     from sqlalchemy.orm import selectinload
 
-    print("\n" + "="*80)
-    print("=== setup_recipient fixture start ===")
-    logger.info("=== setup_recipient fixture start ===")
+    logger.debug("setup_recipient fixture start")
 
     # マネージャーを作成（事業所も自動作成される）
     manager = await manager_user_factory(session=db_session)
     await db_session.flush()  # Flush changes without committing (allows rollback)
-    print(f"Manager created: {manager.email}, id: {manager.id}")
-    logger.info(f"Manager created: {manager.email}, id: {manager.id}")
+    logger.debug("Manager created: id=%s", manager.id)
 
     # マネージャーの所属事業所を取得
     office = manager.office_associations[0].office
-    print(f"Office: {office.name}, id: {office.id}")
-    logger.info(f"Office: {office.name}, id: {office.id}")
+    logger.debug("Office loaded: id=%s", office.id)
 
     # 利用者を作成
     recipient = WelfareRecipient(
@@ -1061,8 +1051,7 @@ async def setup_recipient(
     )
     db_session.add(recipient)
     await db_session.flush()
-    print(f"Recipient created: {recipient.id}")
-    logger.info(f"Recipient created: {recipient.id}")
+    logger.debug("Recipient created: id=%s", recipient.id)
 
     # 事業所との関連付けを作成
     office_recipient_association = OfficeWelfareRecipient(
@@ -1076,43 +1065,30 @@ async def setup_recipient(
     # トークンを生成
     access_token_expires = timedelta(minutes=settings.ACCESS_TOKEN_EXPIRE_MINUTES)
     access_token = create_access_token(str(manager.id), access_token_expires)
-    print(f"Token created: {access_token[:30]}...")
-    logger.info(f"Token created: {access_token[:30]}...")
+    logger.debug("Access token created for setup_recipient")
 
     # get_current_userをオーバーライド
     async def override_get_current_user():
-        print(f"\n{'='*80}")
-        print(f"=== override_get_current_user called in setup_recipient ===")
-        logger.info(f"=== override_get_current_user called in setup_recipient ===")
+        logger.debug("override_get_current_user called in setup_recipient")
         stmt = select(Staff).where(Staff.id == manager.id).options(
             selectinload(Staff.office_associations).selectinload(OfficeStaff.office)
         )
         result = await db_session.execute(stmt)
         user = result.scalars().first()
-        print(f"Returning user from override: {user.email if user else 'None'}")
-        print(f"{'='*80}\n")
-        logger.info(f"Returning user from override: {user.email if user else 'None'}")
+        logger.debug("Returning user from setup_recipient override: id=%s", user.id if user else None)
         return user
 
     app.dependency_overrides[get_current_user] = override_get_current_user
-    print("dependency_overrides set for get_current_user")
-    print(f"Current overrides: {list(app.dependency_overrides.keys())}")
-    print("="*80 + "\n")
-    logger.info("dependency_overrides set for get_current_user")
+    logger.debug("dependency_overrides set for get_current_user")
 
     token_headers = {"Authorization": f"Bearer {access_token}"}
 
     yield recipient, manager, office, token_headers
 
     # クリーンアップ
-    print("\n" + "="*80)
-    print("=== setup_recipient fixture cleanup ===")
-    logger.info("=== setup_recipient fixture cleanup ===")
+    logger.debug("setup_recipient fixture cleanup")
     app.dependency_overrides.pop(get_current_user, None)
-    print("dependency_overrides removed for get_current_user")
-    print(f"Current overrides after cleanup: {list(app.dependency_overrides.keys())}")
-    print("="*80 + "\n")
-    logger.info("dependency_overrides removed for get_current_user")
+    logger.debug("dependency_overrides removed for get_current_user")
 
 
 @pytest_asyncio.fixture

--- a/tests/crud/test_staff_crud.py
+++ b/tests/crud/test_staff_crud.py
@@ -1,6 +1,5 @@
 import pytest
 import uuid
-import logging
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app import crud
@@ -41,18 +40,11 @@ async def test_create_admin_user(db_session: AsyncSession) -> None:
 
 async def test_get_staff_with_office(db_session: AsyncSession, employee_user_factory, office_factory):
     """正常系: 事業所に所属するスタッフを取得した際、事業所情報も読み込まれることをテスト"""
-    # SQLログを有効化
-    import logging
-    logging.basicConfig()
-    logging.getLogger('sqlalchemy.engine').setLevel(logging.INFO)
-
     # Arrange
     # 1. テスト用のスタッフと、そのスタッフが作成者となる事業所を作成
     test_staff = await employee_user_factory(email="relation_test@example.com", with_office=False)
-    print(f"\n[DEBUG] Created test_staff: id={test_staff.id}, full_name={test_staff.full_name}")
 
     test_office = await office_factory(name="リレーションテスト事業所", creator=test_staff)
-    print(f"[DEBUG] Created test_office: id={test_office.id}, name={test_office.name}")
 
     # 2. スタッフと事業所を紐付ける
     from app.models.office import OfficeStaff
@@ -64,40 +56,13 @@ async def test_get_staff_with_office(db_session: AsyncSession, employee_user_fac
     association = OfficeStaff(staff_id=staff_id, office_id=office_id, is_primary=True)
     db_session.add(association)
     await db_session.flush()
-    print(f"[DEBUG] Created association: staff_id={association.staff_id}, office_id={association.office_id}, is_primary={association.is_primary}")
-
-    # デバッグ: DBに実際にデータが保存されているか確認
-    from sqlalchemy import select, text
-    check_query = text("SELECT * FROM office_staffs WHERE staff_id = :staff_id")
-    result = await db_session.execute(check_query, {"staff_id": str(staff_id)})
-    rows = result.fetchall()
-    print(f"[DEBUG] Direct SQL check - office_staffs records: {len(rows)}")
-    for row in rows:
-        print(f"[DEBUG]   {row}")
 
     # セッションの状態をクリアして、次のクエリで確実にDBから取得させる
     db_session.expire_all()
-    print("[DEBUG] Called db_session.expire_all()")
 
     # Act
     # CRUDのgetメソッドでスタッフを再取得
-    print("\n[DEBUG] === Calling crud.staff.get() ===")
     retrieved_staff = await crud.staff.get(db=db_session, id=staff_id)
-
-    # Debug: 取得したスタッフの情報を出力
-    print(f"\n[DEBUG] Retrieved staff: id={retrieved_staff.id if retrieved_staff else None}")
-    if retrieved_staff:
-        print(f"[DEBUG] retrieved_staff.office_associations: {retrieved_staff.office_associations}")
-        print(f"[DEBUG] len(office_associations): {len(retrieved_staff.office_associations)}")
-
-        if retrieved_staff.office_associations:
-            for idx, assoc in enumerate(retrieved_staff.office_associations):
-                print(f"[DEBUG] association[{idx}]: id={assoc.id}, is_primary={assoc.is_primary}")
-                print(f"[DEBUG] association[{idx}].office: {assoc.office}")
-                if assoc.office:
-                    print(f"[DEBUG] association[{idx}].office.id: {assoc.office.id}, name: {assoc.office.name}")
-
-        print(f"[DEBUG] retrieved_staff.office (property): {retrieved_staff.office}")
 
     # Assert
     assert retrieved_staff is not None

--- a/tests/scheduler/test_billing_scheduler.py
+++ b/tests/scheduler/test_billing_scheduler.py
@@ -1,0 +1,55 @@
+from apscheduler.schedulers.asyncio import AsyncIOScheduler
+
+import app.main as main
+import app.scheduler.billing_scheduler as billing_scheduler_module
+
+
+class TestBillingScheduler:
+    def test_main_uses_billing_scheduler_module_wrapper(self):
+        """
+        main.py は AsyncIOScheduler インスタンスではなく、
+        job登録を行う billing_scheduler module wrapper を参照する。
+        """
+        assert main.billing_scheduler is billing_scheduler_module
+
+    def test_start_registers_billing_jobs(self, monkeypatch):
+        """start() wrapper が課金バッチ用 job を登録することを検証。"""
+        scheduler = AsyncIOScheduler()
+        monkeypatch.setattr(billing_scheduler_module, "billing_scheduler", scheduler)
+
+        billing_scheduler_module.start()
+
+        try:
+            job_ids = {job.id for job in scheduler.get_jobs()}
+            assert job_ids == {
+                "check_trial_expiration",
+                "check_scheduled_cancellation",
+            }
+            assert scheduler.running is True
+        finally:
+            billing_scheduler_module.shutdown()
+
+    def test_multiple_start_calls_do_not_duplicate_jobs(self, monkeypatch):
+        """start() を複数回呼んでも job が重複しないことを検証。"""
+        scheduler = AsyncIOScheduler()
+        monkeypatch.setattr(billing_scheduler_module, "billing_scheduler", scheduler)
+
+        billing_scheduler_module.start()
+        billing_scheduler_module.start()
+
+        try:
+            jobs = scheduler.get_jobs()
+            assert len(jobs) == 2
+            assert {job.id for job in jobs} == {
+                "check_trial_expiration",
+                "check_scheduled_cancellation",
+            }
+        finally:
+            billing_scheduler_module.shutdown()
+
+    def test_shutdown_before_start_is_safe(self, monkeypatch):
+        """未起動状態で shutdown() を呼んでも例外にならないことを検証。"""
+        scheduler = AsyncIOScheduler()
+        monkeypatch.setattr(billing_scheduler_module, "billing_scheduler", scheduler)
+
+        billing_scheduler_module.shutdown()

--- a/tests/services/test_billing_canceling.py
+++ b/tests/services/test_billing_canceling.py
@@ -102,6 +102,118 @@ async def active_subscription_setup(db: AsyncSession) -> Tuple:
     return (office.id, staff.id, billing.id, customer_id, subscription_id)
 
 
+@pytest.fixture(scope="function")
+async def trial_expired_subscription_setup(db: AsyncSession) -> Tuple:
+    """
+    試用期限切れだがStripe Subscriptionが残っているBillingを作成する。
+    Returns: (office_id, staff_id, billing_id, customer_id, subscription_id)
+    """
+    staff = Staff(
+        first_name="テスト",
+        last_name="ユーザー",
+        full_name="テスト ユーザー",
+        email=f"test_{uuid4().hex[:8]}@example.com",
+        hashed_password=get_password_hash("password"),
+        role=StaffRole.owner,
+        is_test_data=True
+    )
+    db.add(staff)
+    await db.flush()
+
+    office = Office(
+        name="テスト事業所",
+        type=OfficeType.type_A_office,
+        created_by=staff.id,
+        last_modified_by=staff.id,
+        is_test_data=True
+    )
+    db.add(office)
+    await db.flush()
+
+    office_staff = OfficeStaff(
+        office_id=office.id,
+        staff_id=staff.id,
+        is_primary=True
+    )
+    db.add(office_staff)
+
+    now = datetime.now(timezone.utc)
+    customer_id = f"cus_test_trial_expired_{uuid4().hex[:8]}"
+    subscription_id = f"sub_test_trial_expired_{uuid4().hex[:8]}"
+
+    billing = Billing(
+        office_id=office.id,
+        billing_status=BillingStatus.trial_expired,
+        stripe_customer_id=customer_id,
+        stripe_subscription_id=subscription_id,
+        trial_start_date=now - timedelta(days=190),
+        trial_end_date=now - timedelta(days=10),
+        current_plan_amount=6000
+    )
+    db.add(billing)
+    await db.flush()
+    await db.commit()
+
+    return (office.id, staff.id, billing.id, customer_id, subscription_id)
+
+
+@pytest.fixture(scope="function")
+async def stale_canceling_expired_trial_setup(db: AsyncSession) -> Tuple:
+    """
+    バッチ未実行や過去のキャンセル操作により、試用期限切れ相当だがcancelingで残っているBillingを作成する。
+    Returns: (office_id, staff_id, billing_id, customer_id, subscription_id)
+    """
+    staff = Staff(
+        first_name="テスト",
+        last_name="ユーザー",
+        full_name="テスト ユーザー",
+        email=f"test_{uuid4().hex[:8]}@example.com",
+        hashed_password=get_password_hash("password"),
+        role=StaffRole.owner,
+        is_test_data=True
+    )
+    db.add(staff)
+    await db.flush()
+
+    office = Office(
+        name="テスト事業所",
+        type=OfficeType.type_A_office,
+        created_by=staff.id,
+        last_modified_by=staff.id,
+        is_test_data=True
+    )
+    db.add(office)
+    await db.flush()
+
+    office_staff = OfficeStaff(
+        office_id=office.id,
+        staff_id=staff.id,
+        is_primary=True
+    )
+    db.add(office_staff)
+
+    now = datetime.now(timezone.utc)
+    customer_id = f"cus_test_stale_canceling_{uuid4().hex[:8]}"
+    subscription_id = f"sub_test_stale_canceling_{uuid4().hex[:8]}"
+
+    billing = Billing(
+        office_id=office.id,
+        billing_status=BillingStatus.canceling,
+        stripe_customer_id=customer_id,
+        stripe_subscription_id=subscription_id,
+        trial_start_date=now - timedelta(days=190),
+        trial_end_date=now - timedelta(days=10),
+        last_payment_date=None,
+        scheduled_cancel_at=now + timedelta(days=30),
+        current_plan_amount=6000
+    )
+    db.add(billing)
+    await db.flush()
+    await db.commit()
+
+    return (office.id, staff.id, billing.id, customer_id, subscription_id)
+
+
 class TestBillingCanceling:
     """キャンセル予定(canceling)状態のテスト"""
 
@@ -141,6 +253,64 @@ class TestBillingCanceling:
         # billing_statusがcancelingになっていることを確認
         billing = await crud.billing.get(db=db, id=billing_id)
         assert billing.billing_status == BillingStatus.canceling
+
+    async def test_process_subscription_updated_trial_expired_cancels_immediately(
+        self,
+        db: AsyncSession,
+        trial_expired_subscription_setup: Tuple,
+        billing_service: BillingService
+    ):
+        """
+        trial_expired は既に利用不可のため、期間終了キャンセル通知でもcancelingを経由せずcanceledにする。
+        """
+        office_id, staff_id, billing_id, customer_id, subscription_id = trial_expired_subscription_setup
+        cancel_at = int((datetime.now(timezone.utc) + timedelta(days=30)).timestamp())
+        subscription_data = {
+            'id': subscription_id,
+            'customer': customer_id,
+            'cancel_at_period_end': True,
+            'cancel_at': cancel_at,
+            'status': 'active'
+        }
+
+        await billing_service.process_subscription_updated(
+            db=db,
+            event_id=f"evt_test_{uuid4().hex[:8]}",
+            subscription_data=subscription_data
+        )
+
+        billing = await crud.billing.get(db=db, id=billing_id)
+        assert billing.billing_status == BillingStatus.canceled
+        assert billing.scheduled_cancel_at is None
+
+    async def test_process_subscription_updated_stale_canceling_expired_trial_cancels_immediately(
+        self,
+        db: AsyncSession,
+        stale_canceling_expired_trial_setup: Tuple,
+        billing_service: BillingService
+    ):
+        """
+        trial期限切れ・未支払いのcanceling残存データは、キャンセル予定通知で即時canceledへ補正する。
+        """
+        office_id, staff_id, billing_id, customer_id, subscription_id = stale_canceling_expired_trial_setup
+        cancel_at = int((datetime.now(timezone.utc) + timedelta(days=30)).timestamp())
+        subscription_data = {
+            'id': subscription_id,
+            'customer': customer_id,
+            'cancel_at_period_end': True,
+            'cancel_at': cancel_at,
+            'status': 'active'
+        }
+
+        await billing_service.process_subscription_updated(
+            db=db,
+            event_id=f"evt_test_{uuid4().hex[:8]}",
+            subscription_data=subscription_data
+        )
+
+        billing = await crud.billing.get(db=db, id=billing_id)
+        assert billing.billing_status == BillingStatus.canceled
+        assert billing.scheduled_cancel_at is None
 
     async def test_process_subscription_updated_not_canceling(
         self,

--- a/tests/services/test_billing_service.py
+++ b/tests/services/test_billing_service.py
@@ -22,14 +22,14 @@ from app import crud
 
 # Configure logging
 logging.basicConfig(
-    level=logging.INFO,
+    level=logging.WARNING,
     format='%(levelname)s:%(name)s:%(message)s'
 )
 
 # Suppress SQLAlchemy logs
 logging.getLogger('sqlalchemy.engine').setLevel(logging.WARNING)
 logging.getLogger('sqlalchemy.pool').setLevel(logging.WARNING)
-logging.getLogger('app').setLevel(logging.INFO)
+logging.getLogger('app').setLevel(logging.WARNING)
 
 pytestmark = pytest.mark.asyncio
 
@@ -140,11 +140,15 @@ class TestBillingServiceTransactionIntegrity:
         billing = await crud.billing.get(db=db, id=billing_id)
         assert billing is not None
 
+        unique_id = uuid4().hex
+        customer_id = f"cus_test_rollback_{unique_id}"
+        event_id = f"evt_test_rollback_{unique_id}"
+
         # Stripe Customer IDを設定
         await crud.billing.update_stripe_customer(
             db=db,
             billing_id=billing_id,
-            stripe_customer_id="cus_test_12345"
+            stripe_customer_id=customer_id
         )
 
         # 初期状態確認
@@ -158,8 +162,8 @@ class TestBillingServiceTransactionIntegrity:
             with pytest.raises(Exception, match="DB Error"):
                 await billing_service.process_payment_succeeded(
                     db=db,
-                    event_id="evt_test_12345",
-                    customer_id="cus_test_12345"
+                    event_id=event_id,
+                    customer_id=customer_id
                 )
 
         # ロールバック後の状態確認
@@ -357,14 +361,66 @@ class TestBillingServiceTransactionIntegrity:
         assert billing_after.billing_status == BillingStatus.active
 
     @pytest.mark.asyncio
-    async def test_process_payment_failed_sets_past_due(
+    async def test_subscription_created_after_payment_succeeded_keeps_early_payment_during_trial(
         self,
         db: AsyncSession,
         setup_office_with_billing: Tuple[UUID, UUID, UUID],
         billing_service: BillingService
     ):
         """
-        支払い失敗処理でステータスがpast_dueになることを検証
+        invoice.payment_succeeded が先に来た後で customer.subscription.created が来ても、
+        trial期間中なら early_payment が維持されることを検証。
+        """
+        office_id, staff_id, billing_id = setup_office_with_billing
+        unique_id = uuid4().hex[:8]
+        customer_id = f"cus_test_event_order_{unique_id}"
+        subscription_id = f"sub_test_event_order_{unique_id}"
+
+        await crud.billing.update_stripe_customer(
+            db=db,
+            billing_id=billing_id,
+            stripe_customer_id=customer_id
+        )
+
+        await billing_service.process_payment_succeeded(
+            db=db,
+            event_id=f"evt_payment_first_{unique_id}",
+            customer_id=customer_id
+        )
+
+        async with AsyncSessionLocal() as new_db:
+            billing_after_payment = await crud.billing.get(db=new_db, id=billing_id)
+            assert billing_after_payment.billing_status == BillingStatus.early_payment
+
+            subscription_data = {
+                "id": subscription_id,
+                "customer": customer_id,
+                "metadata": {
+                    "office_id": str(office_id),
+                    "office_name": "テスト事業所",
+                    "created_by_user_id": str(staff_id)
+                }
+            }
+
+            await billing_service.process_subscription_created(
+                db=new_db,
+                event_id=f"evt_subscription_after_payment_{unique_id}",
+                subscription_data=subscription_data
+            )
+
+            billing_after_subscription = await crud.billing.get(db=new_db, id=billing_id)
+            assert billing_after_subscription.billing_status == BillingStatus.early_payment
+            assert billing_after_subscription.stripe_subscription_id == subscription_id
+
+    @pytest.mark.asyncio
+    async def test_process_payment_failed_during_trial_keeps_free_status(
+        self,
+        db: AsyncSession,
+        setup_office_with_billing: Tuple[UUID, UUID, UUID],
+        billing_service: BillingService
+    ):
+        """
+        新仕様: trial期間中の支払い失敗ではpast_due/payment_failedへ落とさないことを検証
         """
         office_id, staff_id, billing_id = setup_office_with_billing
 
@@ -389,9 +445,92 @@ class TestBillingServiceTransactionIntegrity:
         # 新しいセッションで検証
         from app.db.session import AsyncSessionLocal
         async with AsyncSessionLocal() as new_db:
-            # ステータスがpast_dueになっていることを確認
             billing_after = await crud.billing.get(db=new_db, id=billing_id)
-            assert billing_after.billing_status == BillingStatus.past_due
+            assert billing_after.billing_status == BillingStatus.free
+
+    @pytest.mark.asyncio
+    async def test_process_payment_failed_after_trial_sets_payment_failed(
+        self,
+        db: AsyncSession,
+        setup_office_with_billing: Tuple[UUID, UUID, UUID],
+        billing_service: BillingService
+    ):
+        """
+        新仕様: trial期間外の支払い失敗はpayment_failedに更新される。
+        """
+        office_id, staff_id, billing_id = setup_office_with_billing
+        unique_id = uuid4().hex[:8]
+        customer_id = f"cus_test_payment_failed_after_trial_{unique_id}"
+
+        billing = await crud.billing.get(db=db, id=billing_id)
+        await crud.billing.update(
+            db=db,
+            db_obj=billing,
+            obj_in={
+                "billing_status": BillingStatus.active,
+                "trial_end_date": datetime.now(timezone.utc) - timedelta(days=1),
+                "stripe_subscription_id": f"sub_test_payment_failed_{unique_id}",
+            },
+            auto_commit=False
+        )
+        await crud.billing.update_stripe_customer(
+            db=db,
+            billing_id=billing_id,
+            stripe_customer_id=customer_id
+        )
+        await db.commit()
+
+        await billing_service.process_payment_failed(
+            db=db,
+            event_id=f"evt_test_payment_failed_after_trial_{unique_id}",
+            customer_id=customer_id
+        )
+
+        async with AsyncSessionLocal() as new_db:
+            billing_after = await crud.billing.get(db=new_db, id=billing_id)
+            assert billing_after.billing_status == BillingStatus.payment_failed
+
+    @pytest.mark.asyncio
+    async def test_process_payment_failed_during_trial_keeps_existing_status(
+        self,
+        db: AsyncSession,
+        setup_office_with_billing: Tuple[UUID, UUID, UUID],
+        billing_service: BillingService
+    ):
+        """
+        新仕様: trial期間中の支払い失敗ではpayment_failed/past_dueへ落とさない。
+        """
+        office_id, staff_id, billing_id = setup_office_with_billing
+        unique_id = uuid4().hex[:8]
+        customer_id = f"cus_test_payment_failed_during_trial_{unique_id}"
+
+        billing = await crud.billing.get(db=db, id=billing_id)
+        await crud.billing.update(
+            db=db,
+            db_obj=billing,
+            obj_in={
+                "billing_status": BillingStatus.early_payment,
+                "trial_end_date": datetime.now(timezone.utc) + timedelta(days=30),
+                "stripe_subscription_id": f"sub_test_trial_payment_failed_{unique_id}",
+            },
+            auto_commit=False
+        )
+        await crud.billing.update_stripe_customer(
+            db=db,
+            billing_id=billing_id,
+            stripe_customer_id=customer_id
+        )
+        await db.commit()
+
+        await billing_service.process_payment_failed(
+            db=db,
+            event_id=f"evt_test_payment_failed_during_trial_{unique_id}",
+            customer_id=customer_id
+        )
+
+        async with AsyncSessionLocal() as new_db:
+            billing_after = await crud.billing.get(db=new_db, id=billing_id)
+            assert billing_after.billing_status == BillingStatus.early_payment
 
     @pytest.mark.asyncio
     async def test_process_subscription_deleted_sets_canceled(
@@ -446,6 +585,62 @@ class TestBillingServiceTransactionIntegrity:
             # ステータスがcanceledになっていることを確認
             billing_after = await crud.billing.get(db=new_db, id=billing_id)
             assert billing_after.billing_status == BillingStatus.canceled
+
+    @pytest.mark.asyncio
+    async def test_process_subscription_deleted_after_recent_payment_failed_keeps_payment_failed(
+        self,
+        db: AsyncSession,
+        setup_office_with_billing: Tuple[UUID, UUID, UUID],
+        billing_service: BillingService
+    ):
+        """
+        支払い失敗直後のStripe自動削除では、ユーザー解約ではなくpayment_failedを優先する。
+        """
+        office_id, staff_id, billing_id = setup_office_with_billing
+
+        unique_id = uuid4().hex[:8]
+        customer_id = f"cus_test_failed_deleted_{unique_id}"
+
+        await crud.billing.update_stripe_customer(
+            db=db,
+            billing_id=billing_id,
+            stripe_customer_id=customer_id
+        )
+        await crud.billing.update_stripe_subscription(
+            db=db,
+            billing_id=billing_id,
+            stripe_subscription_id=f"sub_test_failed_deleted_{unique_id}"
+        )
+        await crud.billing.update_status(
+            db=db,
+            billing_id=billing_id,
+            status=BillingStatus.payment_failed
+        )
+
+        billing = await crud.billing.get(db=db, id=billing_id)
+        await crud.webhook_event.create_event_record(
+            db=db,
+            event_id=f"evt_recent_payment_failed_{unique_id}",
+            event_type="invoice.payment_failed",
+            source="stripe",
+            billing_id=billing_id,
+            office_id=office_id,
+            payload={"customer_id": customer_id},
+            status="success",
+            auto_commit=False
+        )
+        await db.commit()
+
+        await billing_service.process_subscription_deleted(
+            db=db,
+            event_id=f"evt_test_deleted_after_failed_{unique_id}",
+            customer_id=customer_id
+        )
+
+        from app.db.session import AsyncSessionLocal
+        async with AsyncSessionLocal() as new_db:
+            billing_after = await crud.billing.get(db=new_db, id=billing_id)
+            assert billing_after.billing_status == BillingStatus.payment_failed
 
 
 class TestBillingServiceMissingCustomerHandling:
@@ -644,6 +839,356 @@ class TestBillingServiceStripeIntegration:
         # DB更新が反映されていることを確認
         billing_after = await crud.billing.get(db=db, id=billing_id)
         assert billing_after.stripe_customer_id == "cus_mock_12345"
+
+    @pytest.mark.asyncio
+    async def test_create_checkout_session_with_customer_excludes_expired_trial_end(
+        self,
+        db: AsyncSession,
+        setup_office_with_billing: Tuple[UUID, UUID, UUID],
+        billing_service: BillingService
+    ):
+        """
+        新規Customer作成ルートでは、過去のtrial_endをStripeに渡さないことを検証。
+        """
+        office_id, staff_id, billing_id = setup_office_with_billing
+        unique_id = uuid4().hex
+        customer_id = f"cus_mock_expired_trial_{unique_id}"
+        checkout_session_id = f"cs_mock_expired_trial_{unique_id}"
+        expired_trial_end = datetime.now(timezone.utc) - timedelta(days=1)
+
+        billing = await crud.billing.get(db=db, id=billing_id)
+        await crud.billing.update(
+            db=db,
+            db_obj=billing,
+            obj_in={"trial_end_date": expired_trial_end},
+            auto_commit=False
+        )
+        await db.flush()
+
+        mock_customer = Mock()
+        mock_customer.id = customer_id
+
+        mock_checkout_session = Mock()
+        mock_checkout_session.id = checkout_session_id
+        mock_checkout_session.url = "https://checkout.stripe.com/expired-trial"
+
+        with patch('stripe.Customer.create', return_value=mock_customer), \
+             patch('stripe.checkout.Session.create', return_value=mock_checkout_session) as mock_create_session:
+            result = await billing_service.create_checkout_session_with_customer(
+                db=db,
+                billing_id=billing_id,
+                office_id=office_id,
+                office_name="期限切れトライアル事業所",
+                user_email="expired-trial@example.com",
+                user_id=staff_id,
+                trial_end_date=expired_trial_end,
+                stripe_secret_key="sk_test_mock",
+                stripe_price_id="price_mock_12345",
+                frontend_url="http://localhost:3000"
+            )
+
+        assert result["session_id"] == checkout_session_id
+        assert result["url"] == "https://checkout.stripe.com/expired-trial"
+
+        mock_create_session.assert_called_once()
+        subscription_data = mock_create_session.call_args.kwargs["subscription_data"]
+        assert "trial_end" not in subscription_data
+
+        billing_after = await crud.billing.get(db=db, id=billing_id)
+        assert billing_after.stripe_customer_id == customer_id
+        assert billing_after.billing_status == BillingStatus.trial_expired
+
+    @pytest.mark.asyncio
+    async def test_create_checkout_session_with_customer_includes_future_trial_end(
+        self,
+        db: AsyncSession,
+        setup_office_with_billing: Tuple[UUID, UUID, UUID],
+        billing_service: BillingService
+    ):
+        """
+        新規Customer作成ルートでは、未来のtrial_endを従来どおりStripeに渡すことを検証。
+        """
+        office_id, staff_id, billing_id = setup_office_with_billing
+        unique_id = uuid4().hex
+        customer_id = f"cus_mock_future_trial_{unique_id}"
+        checkout_session_id = f"cs_mock_future_trial_{unique_id}"
+        future_trial_end = datetime.now(timezone.utc) + timedelta(days=30)
+
+        mock_customer = Mock()
+        mock_customer.id = customer_id
+
+        mock_checkout_session = Mock()
+        mock_checkout_session.id = checkout_session_id
+        mock_checkout_session.url = "https://checkout.stripe.com/future-trial"
+
+        with patch('stripe.Customer.create', return_value=mock_customer), \
+             patch('stripe.checkout.Session.create', return_value=mock_checkout_session) as mock_create_session:
+            result = await billing_service.create_checkout_session_with_customer(
+                db=db,
+                billing_id=billing_id,
+                office_id=office_id,
+                office_name="トライアル中事業所",
+                user_email="future-trial@example.com",
+                user_id=staff_id,
+                trial_end_date=future_trial_end,
+                stripe_secret_key="sk_test_mock",
+                stripe_price_id="price_mock_12345",
+                frontend_url="http://localhost:3000"
+            )
+
+        assert result["session_id"] == checkout_session_id
+        assert result["url"] == "https://checkout.stripe.com/future-trial"
+
+        mock_create_session.assert_called_once()
+        subscription_data = mock_create_session.call_args.kwargs["subscription_data"]
+        assert subscription_data["trial_end"] == int(future_trial_end.timestamp())
+
+    @pytest.mark.asyncio
+    async def test_create_checkout_session_with_customer_accepts_naive_trial_end(
+        self,
+        db: AsyncSession,
+        setup_office_with_billing: Tuple[UUID, UUID, UUID],
+        billing_service: BillingService
+    ):
+        """
+        新規Customer作成ルートでは、naive datetimeでも比較エラーにならずtrial_endを渡すことを検証。
+        """
+        office_id, staff_id, billing_id = setup_office_with_billing
+        unique_id = uuid4().hex
+        customer_id = f"cus_mock_naive_trial_{unique_id}"
+        checkout_session_id = f"cs_mock_naive_trial_{unique_id}"
+        naive_trial_end = datetime.now() + timedelta(days=30)
+
+        mock_customer = Mock()
+        mock_customer.id = customer_id
+
+        mock_checkout_session = Mock()
+        mock_checkout_session.id = checkout_session_id
+        mock_checkout_session.url = "https://checkout.stripe.com/naive-trial"
+
+        with patch('stripe.Customer.create', return_value=mock_customer), \
+             patch('stripe.checkout.Session.create', return_value=mock_checkout_session) as mock_create_session:
+            result = await billing_service.create_checkout_session_with_customer(
+                db=db,
+                billing_id=billing_id,
+                office_id=office_id,
+                office_name="naive datetime事業所",
+                user_email="naive-trial@example.com",
+                user_id=staff_id,
+                trial_end_date=naive_trial_end,
+                stripe_secret_key="sk_test_mock",
+                stripe_price_id="price_mock_12345",
+                frontend_url="http://localhost:3000"
+            )
+
+        assert result["session_id"] == checkout_session_id
+        assert result["url"] == "https://checkout.stripe.com/naive-trial"
+
+        mock_create_session.assert_called_once()
+        subscription_data = mock_create_session.call_args.kwargs["subscription_data"]
+        assert subscription_data["trial_end"] == int(
+            naive_trial_end.replace(tzinfo=timezone.utc).timestamp()
+        )
+
+    @pytest.mark.asyncio
+    async def test_create_checkout_session_rollback_on_checkout_session_error(
+        self,
+        db: AsyncSession,
+        setup_office_with_billing: Tuple[UUID, UUID, UUID],
+        billing_service: BillingService
+    ):
+        """
+        Customer作成後にCheckout Session作成が失敗した場合、DB更新がロールバックされることを検証。
+        """
+        office_id, staff_id, billing_id = setup_office_with_billing
+        unique_id = uuid4().hex
+        customer_id = f"cus_mock_checkout_error_{unique_id}"
+        expired_trial_end = datetime.now(timezone.utc) - timedelta(days=1)
+
+        billing = await crud.billing.get(db=db, id=billing_id)
+        await crud.billing.update(
+            db=db,
+            db_obj=billing,
+            obj_in={
+                "billing_status": BillingStatus.free,
+                "trial_end_date": expired_trial_end,
+            },
+            auto_commit=False
+        )
+        await db.commit()
+
+        mock_customer = Mock()
+        mock_customer.id = customer_id
+
+        import stripe
+        with patch('stripe.Customer.create', return_value=mock_customer), \
+             patch('stripe.checkout.Session.create', side_effect=stripe.error.StripeError("Checkout Error")):
+            from fastapi import HTTPException
+            with pytest.raises(HTTPException):
+                await billing_service.create_checkout_session_with_customer(
+                    db=db,
+                    billing_id=billing_id,
+                    office_id=office_id,
+                    office_name="Checkout失敗事業所",
+                    user_email="checkout-error@example.com",
+                    user_id=staff_id,
+                    trial_end_date=expired_trial_end,
+                    stripe_secret_key="sk_test_mock",
+                    stripe_price_id="price_mock_12345",
+                    frontend_url="http://localhost:3000"
+                )
+
+        billing_after = await crud.billing.get(db=db, id=billing_id)
+        assert billing_after.stripe_customer_id is None
+        assert billing_after.billing_status == BillingStatus.free
+
+    @pytest.mark.asyncio
+    async def test_create_checkout_session_logs_safe_context_on_stripe_error(
+        self,
+        db: AsyncSession,
+        setup_office_with_billing: Tuple[UUID, UUID, UUID],
+        billing_service: BillingService,
+        caplog
+    ):
+        """
+        Stripe APIエラー時に、秘匿情報を含めず調査用コンテキストをログ出力することを検証。
+        """
+        office_id, staff_id, billing_id = setup_office_with_billing
+        billing = await crud.billing.get(db=db, id=billing_id)
+
+        secret_key = "sk_test_secret_should_not_be_logged"
+        user_email = "sensitive-user@example.com"
+        leaked_customer_id = f"cus_leaked_error_{uuid4().hex}"
+        stripe_error_message = f"No such customer: {leaked_customer_id}; email={user_email}"
+
+        import stripe
+        with caplog.at_level(logging.ERROR, logger="app.services.billing_service"):
+            with patch('stripe.Customer.create', side_effect=stripe.error.StripeError(stripe_error_message)):
+                from fastapi import HTTPException
+                with pytest.raises(HTTPException):
+                    await billing_service.create_checkout_session_with_customer(
+                        db=db,
+                        billing_id=billing_id,
+                        office_id=office_id,
+                        office_name="ログ検証事業所",
+                        user_email=user_email,
+                        user_id=staff_id,
+                        trial_end_date=billing.trial_end_date,
+                        stripe_secret_key=secret_key,
+                        stripe_price_id="price_mock_12345",
+                        frontend_url="http://localhost:3000"
+                    )
+
+        assert f"billing_id={billing_id}" in caplog.text
+        assert f"office_id={office_id}" in caplog.text
+        assert "checkout_route=new_customer" in caplog.text
+        assert "has_stripe_customer_id=False" in caplog.text
+        assert "billing_status=free" in caplog.text
+        assert "trial_end_date=" in caplog.text
+        assert "stripe_error_type=StripeError" in caplog.text
+        assert secret_key not in caplog.text
+        assert user_email not in caplog.text
+        assert leaked_customer_id not in caplog.text
+        assert stripe_error_message not in caplog.text
+
+    @pytest.mark.asyncio
+    async def test_create_checkout_session_existing_customer_logs_safe_context_on_stripe_error(
+        self,
+        db: AsyncSession,
+        setup_office_with_billing: Tuple[UUID, UUID, UUID],
+        billing_service: BillingService,
+        caplog
+    ):
+        """
+        既存CustomerありルートのStripe APIエラーでも、非秘匿の調査情報をログ出力することを検証。
+        """
+        office_id, staff_id, billing_id = setup_office_with_billing
+        customer_id = f"cus_existing_log_{uuid4().hex}"
+
+        await crud.billing.update_stripe_customer(
+            db=db,
+            billing_id=billing_id,
+            stripe_customer_id=customer_id
+        )
+        await db.commit()
+
+        billing = await crud.billing.get(db=db, id=billing_id)
+        user_email = "existing-sensitive-user@example.com"
+        stripe_error_message = f"No such customer: {customer_id}; email={user_email}"
+
+        import stripe
+        with caplog.at_level(logging.ERROR, logger="app.services.billing_service"):
+            with patch('stripe.checkout.Session.create', side_effect=stripe.error.StripeError(stripe_error_message)):
+                from fastapi import HTTPException
+                with pytest.raises(HTTPException):
+                    await billing_service.create_checkout_session_for_existing_customer(
+                        db=db,
+                        billing_id=billing_id,
+                        office_id=office_id,
+                        office_name="既存Customerログ検証事業所",
+                        user_id=staff_id,
+                        stripe_customer_id=customer_id,
+                        trial_end_date=billing.trial_end_date,
+                        stripe_secret_key="sk_test_existing_customer_log",
+                        stripe_price_id="price_mock_12345",
+                        frontend_url="http://localhost:3000"
+                    )
+
+        assert f"billing_id={billing_id}" in caplog.text
+        assert f"office_id={office_id}" in caplog.text
+        assert "checkout_route=existing_customer" in caplog.text
+        assert "has_stripe_customer_id=True" in caplog.text
+        assert "billing_status=free" in caplog.text
+        assert "trial_end_date=" in caplog.text
+        assert "stripe_error_type=StripeError" in caplog.text
+        assert customer_id not in caplog.text
+        assert user_email not in caplog.text
+        assert stripe_error_message not in caplog.text
+
+    @pytest.mark.asyncio
+    async def test_create_checkout_session_existing_customer_sets_stripe_api_key(
+        self,
+        db: AsyncSession,
+        setup_office_with_billing: Tuple[UUID, UUID, UUID],
+        billing_service: BillingService
+    ):
+        """
+        既存CustomerありルートでもCheckout作成前にStripe APIキーを設定することを検証。
+        """
+        office_id, staff_id, billing_id = setup_office_with_billing
+        customer_id = f"cus_existing_api_key_{uuid4().hex}"
+        secret_key = "sk_test_existing_customer_route"
+
+        await crud.billing.update_stripe_customer(
+            db=db,
+            billing_id=billing_id,
+            stripe_customer_id=customer_id
+        )
+        await db.commit()
+
+        billing = await crud.billing.get(db=db, id=billing_id)
+        mock_checkout_session = Mock()
+        mock_checkout_session.id = f"cs_existing_api_key_{uuid4().hex}"
+        mock_checkout_session.url = "https://checkout.stripe.com/existing-api-key"
+
+        import stripe
+        stripe.api_key = None
+
+        with patch('stripe.checkout.Session.create', return_value=mock_checkout_session):
+            await billing_service.create_checkout_session_for_existing_customer(
+                db=db,
+                billing_id=billing_id,
+                office_id=office_id,
+                office_name="既存Customer APIキー検証事業所",
+                user_id=staff_id,
+                stripe_customer_id=customer_id,
+                trial_end_date=billing.trial_end_date,
+                stripe_secret_key=secret_key,
+                stripe_price_id="price_mock_12345",
+                frontend_url="http://localhost:3000"
+            )
+
+        assert stripe.api_key == secret_key
 
     @pytest.mark.asyncio
     async def test_create_checkout_session_rollback_on_stripe_error(

--- a/tests/services/test_billing_status_helpers.py
+++ b/tests/services/test_billing_status_helpers.py
@@ -4,7 +4,10 @@ BillingService ステータス運用ヘルパーメソッドのTDDテスト
 ユーザーが便利に使えるステータス判定・操作メソッドをテスト
 """
 import pytest
+from fastapi import HTTPException
+from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import selectinload
 from uuid import uuid4
 from datetime import datetime, timezone, timedelta
 from typing import Tuple
@@ -15,6 +18,7 @@ from app.models.office import Office, OfficeStaff
 from app.models.billing import Billing
 from app.models.enums import StaffRole, OfficeType, BillingStatus
 from app.core.security import get_password_hash
+from app.api.deps import require_active_billing
 from app import crud
 
 pytestmark = pytest.mark.asyncio
@@ -174,33 +178,31 @@ class TestBillingStatusChecks:
     ):
         """
         有料機能にアクセスできるかを判定
-        early_payment, active, canceling は True
-        free, past_due, canceled は False
+        early_payment, active, canceling は True。
+        free, past_due, trial_expired, payment_failed, canceled は False。
         """
-        # early_payment: True
-        billing_id, _, _ = await billing_factory(BillingStatus.early_payment)
-        billing = await crud.billing.get(db=db, id=billing_id)
-        assert crud.billing.can_access_paid_features(billing) is True
+        allowed_statuses = [
+            BillingStatus.early_payment,
+            BillingStatus.active,
+            BillingStatus.canceling,
+        ]
+        restricted_statuses = [
+            BillingStatus.free,
+            BillingStatus.past_due,
+            BillingStatus.trial_expired,
+            BillingStatus.payment_failed,
+            BillingStatus.canceled,
+        ]
 
-        # active: True
-        billing_id, _, _ = await billing_factory(BillingStatus.active)
-        billing = await crud.billing.get(db=db, id=billing_id)
-        assert crud.billing.can_access_paid_features(billing) is True
+        for status in allowed_statuses:
+            billing_id, _, _ = await billing_factory(status)
+            billing = await crud.billing.get(db=db, id=billing_id)
+            assert crud.billing.can_access_paid_features(billing) is True
 
-        # canceling: True (期間終了まで利用可能)
-        billing_id, _, _ = await billing_factory(BillingStatus.canceling)
-        billing = await crud.billing.get(db=db, id=billing_id)
-        assert crud.billing.can_access_paid_features(billing) is True
-
-        # free: False
-        billing_id, _, _ = await billing_factory(BillingStatus.free)
-        billing = await crud.billing.get(db=db, id=billing_id)
-        assert crud.billing.can_access_paid_features(billing) is False
-
-        # past_due: False
-        billing_id, _, _ = await billing_factory(BillingStatus.past_due)
-        billing = await crud.billing.get(db=db, id=billing_id)
-        assert crud.billing.can_access_paid_features(billing) is False
+        for status in restricted_statuses:
+            billing_id, _, _ = await billing_factory(status)
+            billing = await crud.billing.get(db=db, id=billing_id)
+            assert crud.billing.can_access_paid_features(billing) is False
 
     async def test_requires_payment_action(
         self,
@@ -226,6 +228,80 @@ class TestBillingStatusChecks:
         billing = await crud.billing.get(db=db, id=billing_id)
         assert crud.billing.requires_payment_action(billing) is False
 
+    async def test_new_statuses_are_restricted_and_require_payment_action(
+        self,
+        db: AsyncSession,
+        billing_factory
+    ):
+        """
+        新仕様: trial_expired/payment_failed は有料機能不可かつ支払いアクション対象。
+        """
+        for status in [BillingStatus.trial_expired, BillingStatus.payment_failed]:
+            billing_id, _, _ = await billing_factory(status)
+            billing = await crud.billing.get(db=db, id=billing_id)
+
+            assert crud.billing.is_active_subscription(billing) is False
+            assert crud.billing.can_access_paid_features(billing) is False
+            assert crud.billing.requires_payment_action(billing) is True
+
+    async def test_require_active_billing_restricts_payment_required_statuses(
+        self,
+        db: AsyncSession,
+        billing_factory
+    ):
+        """
+        書き込み操作向けdependencyは支払い対応が必要なstatusを402で制限する。
+        """
+        restricted_statuses = [
+            BillingStatus.past_due,
+            BillingStatus.trial_expired,
+            BillingStatus.payment_failed,
+            BillingStatus.canceled,
+        ]
+
+        for billing_status in restricted_statuses:
+            _, _, staff_id = await billing_factory(billing_status)
+            result = await db.execute(
+                select(Staff)
+                .where(Staff.id == staff_id)
+                .options(selectinload(Staff.office_associations))
+            )
+            staff = result.scalars().one()
+
+            with pytest.raises(HTTPException) as exc_info:
+                await require_active_billing(db=db, current_staff=staff)
+
+            assert exc_info.value.status_code == 402
+
+    async def test_require_active_billing_allows_usable_statuses(
+        self,
+        db: AsyncSession,
+        billing_factory
+    ):
+        """
+        書き込み操作向けdependencyは利用可能statusを通す。
+
+        free は有料機能判定では False だが、無料期間中の通常利用を許可するため
+        require_active_billing では制限対象に含めない。
+        """
+        allowed_statuses = [
+            BillingStatus.free,
+            BillingStatus.early_payment,
+            BillingStatus.active,
+            BillingStatus.canceling,
+        ]
+
+        for billing_status in allowed_statuses:
+            _, _, staff_id = await billing_factory(billing_status)
+            result = await db.execute(
+                select(Staff)
+                .where(Staff.id == staff_id)
+                .options(selectinload(Staff.office_associations))
+            )
+            staff = result.scalars().one()
+
+            assert await require_active_billing(db=db, current_staff=staff) == staff
+
 
 class TestBillingStatusMessages:
     """ステータスメッセージ取得のテスト"""
@@ -245,6 +321,26 @@ class TestBillingStatusMessages:
             (BillingStatus.past_due, "支払い遅延"),
             (BillingStatus.canceling, "キャンセル予定"),
             (BillingStatus.canceled, "キャンセル済み"),
+        ]
+
+        for status, expected_message in test_cases:
+            billing_id, _, _ = await billing_factory(status)
+            billing = await crud.billing.get(db=db, id=billing_id)
+
+            message = crud.billing.get_status_display_message(billing)
+            assert message == expected_message
+
+    async def test_get_status_display_message_for_new_statuses(
+        self,
+        db: AsyncSession,
+        billing_factory
+    ):
+        """
+        新仕様: trial_expired/payment_failed の表示文言を分離する。
+        """
+        test_cases = [
+            (BillingStatus.trial_expired, "無料期間終了"),
+            (BillingStatus.payment_failed, "支払い失敗"),
         ]
 
         for status, expected_message in test_cases:
@@ -303,3 +399,21 @@ class TestBillingStatusMessages:
         billing = await crud.billing.get(db=db, id=billing_id)
         message = crud.billing.get_next_action_message(billing)
         assert "再契約" in message or "再開" in message
+
+    async def test_get_next_action_message_for_new_statuses(
+        self,
+        db: AsyncSession,
+        billing_factory
+    ):
+        """
+        新仕様: trial_expired/payment_failed で次アクションを分ける。
+        """
+        billing_id, _, _ = await billing_factory(BillingStatus.trial_expired)
+        billing = await crud.billing.get(db=db, id=billing_id)
+        message = crud.billing.get_next_action_message(billing)
+        assert "サブスクリプション" in message or "課金登録" in message
+
+        billing_id, _, _ = await billing_factory(BillingStatus.payment_failed)
+        billing = await crud.billing.get(db=db, id=billing_id)
+        message = crud.billing.get_next_action_message(billing)
+        assert "支払い方法" in message or "再決済" in message

--- a/tests/services/test_employee_action_service.py
+++ b/tests/services/test_employee_action_service.py
@@ -19,14 +19,14 @@ from app.services.employee_action_service import employee_action_service
 
 # Configure logging
 logging.basicConfig(
-    level=logging.INFO,
+    level=logging.WARNING,
     format='%(levelname)s:%(name)s:%(message)s'
 )
 
 # Suppress SQLAlchemy logs
 logging.getLogger('sqlalchemy.engine').setLevel(logging.WARNING)
 logging.getLogger('sqlalchemy.pool').setLevel(logging.WARNING)
-logging.getLogger('app').setLevel(logging.INFO)
+logging.getLogger('app').setLevel(logging.WARNING)
 
 pytestmark = pytest.mark.asyncio
 

--- a/tests/services/test_role_change_service.py
+++ b/tests/services/test_role_change_service.py
@@ -15,14 +15,14 @@ from app.services.role_change_service import role_change_service
 
 # Configure logging
 logging.basicConfig(
-    level=logging.INFO,
+    level=logging.WARNING,
     format='%(levelname)s:%(name)s:%(message)s'
 )
 
 # Suppress SQLAlchemy logs
 logging.getLogger('sqlalchemy.engine').setLevel(logging.WARNING)
 logging.getLogger('sqlalchemy.pool').setLevel(logging.WARNING)
-logging.getLogger('app').setLevel(logging.INFO)
+logging.getLogger('app').setLevel(logging.WARNING)
 
 pytestmark = pytest.mark.asyncio
 

--- a/tests/services/test_support_plan_service.py
+++ b/tests/services/test_support_plan_service.py
@@ -20,7 +20,7 @@ from app.core.exceptions import InvalidStepOrderError
 
 # Configure logging to suppress SQL statements and show only application logs
 logging.basicConfig(
-    level=logging.INFO,
+    level=logging.WARNING,
     format='%(levelname)s:%(name)s:%(message)s'
 )
 
@@ -31,7 +31,7 @@ logging.getLogger('sqlalchemy.dialects').setLevel(logging.WARNING)
 logging.getLogger('sqlalchemy.orm').setLevel(logging.WARNING)
 
 # Keep application logs visible
-logging.getLogger('app').setLevel(logging.INFO)
+logging.getLogger('app').setLevel(logging.WARNING)
 
 
 pytestmark = pytest.mark.asyncio

--- a/tests/services/test_withdrawal_service.py
+++ b/tests/services/test_withdrawal_service.py
@@ -22,14 +22,14 @@ from app.crud.crud_archived_staff import crud_archived_staff
 
 # Configure logging
 logging.basicConfig(
-    level=logging.INFO,
+    level=logging.WARNING,
     format='%(levelname)s:%(name)s:%(message)s'
 )
 
 # Suppress SQLAlchemy logs
 logging.getLogger('sqlalchemy.engine').setLevel(logging.WARNING)
 logging.getLogger('sqlalchemy.pool').setLevel(logging.WARNING)
-logging.getLogger('app').setLevel(logging.INFO)
+logging.getLogger('app').setLevel(logging.WARNING)
 
 pytestmark = pytest.mark.asyncio
 

--- a/tests/tasks/test_billing_check.py
+++ b/tests/tasks/test_billing_check.py
@@ -1,6 +1,8 @@
 """
 課金バッチ処理のテスト（TDD）
 """
+import logging
+
 import pytest
 from datetime import datetime, timedelta, timezone
 from uuid import uuid4
@@ -19,18 +21,18 @@ def assert_updated_at_least(actual_count: int, expected_own_records: int) -> Non
 class TestTrialExpirationCheck:
     """トライアル期間終了チェックのテスト"""
 
-    async def test_expired_trial_updates_to_past_due(
+    async def test_expired_trial_updates_to_trial_expired_legacy_case(
         self,
         db_session,
         office_factory,
         staff_factory
     ):
         """
-        トライアル期限切れのBillingがpast_dueに更新される
+        トライアル期限切れのBillingがtrial_expiredに更新される
 
         Given: trial_end_date が過去 かつ billing_status = 'free'
         When: check_trial_expiration() 実行
-        Then: billing_status が 'past_due' に更新される
+        Then: billing_status が 'trial_expired' に更新される
         """
         # テスト用事務所作成
         office = await office_factory(session=db_session, is_test_data=True)
@@ -54,7 +56,40 @@ class TestTrialExpirationCheck:
 
         # 検証
         await db_session.refresh(billing)
-        assert billing.billing_status == BillingStatus.past_due
+        assert billing.billing_status == BillingStatus.trial_expired
+        assert_updated_at_least(expired_count, 1)
+
+    async def test_expired_trial_updates_to_trial_expired(
+        self,
+        db_session,
+        office_factory
+    ):
+        """
+        新仕様: トライアル期限切れ・未課金のBillingはtrial_expiredに更新される。
+
+        Given: trial_end_date が過去 かつ billing_status = 'free'
+        When: check_trial_expiration() 実行
+        Then: billing_status が 'trial_expired' に更新される
+        """
+        office = await office_factory(session=db_session, is_test_data=True)
+        await db_session.commit()
+
+        billing = await crud.billing.create_for_office(
+            db=db_session,
+            office_id=office.id,
+            trial_days=180
+        )
+        await db_session.commit()
+
+        billing.trial_end_date = datetime.now(timezone.utc) - timedelta(days=1)
+        billing.billing_status = BillingStatus.free
+        billing.stripe_subscription_id = None
+        await db_session.commit()
+
+        expired_count = await check_trial_expiration(db=db_session)
+
+        await db_session.refresh(billing)
+        assert billing.billing_status == BillingStatus.trial_expired
         assert_updated_at_least(expired_count, 1)
 
     async def test_active_trial_not_updated(
@@ -177,7 +212,7 @@ class TestTrialExpirationCheck:
 
         Given: 3つのBillingがトライアル期限切れ
         When: check_trial_expiration() 実行
-        Then: 3つ全てが past_due に更新される
+        Then: 3つ全てが trial_expired に更新される
         """
         # テスト用事務所を3つ作成
         billings = []
@@ -202,11 +237,11 @@ class TestTrialExpirationCheck:
         # バッチ処理実行
         expired_count = await check_trial_expiration(db=db_session)
 
-        # 検証（作成したBillingがすべて past_due に更新されていることを確認）
+        # 検証（作成したBillingがすべて trial_expired に更新されていることを確認）
         assert_updated_at_least(expired_count, 3)
         for billing in billings:
             await db_session.refresh(billing)
-            assert billing.billing_status == BillingStatus.past_due
+            assert billing.billing_status == BillingStatus.trial_expired
 
     async def test_past_due_already_not_updated(
         self,
@@ -244,6 +279,72 @@ class TestTrialExpirationCheck:
         await db_session.refresh(billing)
         assert billing.billing_status == BillingStatus.past_due
 
+    async def test_past_due_during_trial_is_not_changed_by_trial_expiration_check(
+        self,
+        db_session,
+        office_factory
+    ):
+        """
+        互換用past_dueはtrial中に見えても、期限切れバッチでは自動補正しない。
+        """
+        office = await office_factory(session=db_session, is_test_data=True)
+        await db_session.commit()
+
+        billing = await crud.billing.create_for_office(
+            db=db_session,
+            office_id=office.id,
+            trial_days=180
+        )
+        await db_session.commit()
+
+        billing.trial_end_date = datetime.now(timezone.utc) + timedelta(days=30)
+        billing.billing_status = BillingStatus.past_due
+        await db_session.commit()
+
+        await check_trial_expiration(db=db_session)
+
+        await db_session.refresh(billing)
+        assert billing.billing_status == BillingStatus.past_due
+
+    async def test_trial_expiration_logs_original_status(
+        self,
+        db_session,
+        office_factory,
+        caplog
+    ):
+        """
+        期限切れバッチのログが更新後ではなく、更新前statusからの遷移を記録する。
+        """
+        office1 = await office_factory(session=db_session, is_test_data=True)
+        await db_session.commit()
+        billing1 = await crud.billing.create_for_office(
+            db=db_session,
+            office_id=office1.id,
+            trial_days=180
+        )
+        await db_session.commit()
+        billing1.trial_end_date = datetime.now(timezone.utc) - timedelta(days=1)
+        billing1.billing_status = BillingStatus.free
+
+        office2 = await office_factory(session=db_session, is_test_data=True)
+        await db_session.commit()
+        billing2 = await crud.billing.create_for_office(
+            db=db_session,
+            office_id=office2.id,
+            trial_days=180
+        )
+        await db_session.commit()
+        billing2.trial_end_date = datetime.now(timezone.utc) - timedelta(days=1)
+        billing2.billing_status = BillingStatus.early_payment
+        billing2.stripe_subscription_id = f"sub_test_log_{uuid4().hex[:12]}"
+        await db_session.commit()
+
+        with caplog.at_level(logging.INFO, logger="app.tasks.billing_check"):
+            await check_trial_expiration(db=db_session)
+
+        assert "free → trial_expired" in caplog.text
+        assert "early_payment → active" in caplog.text
+
     async def test_timezone_aware_comparison(
         self,
         db_session,
@@ -278,7 +379,7 @@ class TestTrialExpirationCheck:
 
         # 検証
         await db_session.refresh(billing)
-        assert billing.billing_status == BillingStatus.past_due
+        assert billing.billing_status == BillingStatus.trial_expired
         assert_updated_at_least(expired_count, 1)
 
     async def test_mixed_statuses_batch_update(
@@ -294,10 +395,10 @@ class TestTrialExpirationCheck:
           - Billing2: early_payment, trial期限切れ
         When: check_trial_expiration() 実行
         Then:
-          - Billing1: past_due に更新
+          - Billing1: trial_expired に更新
           - Billing2: active に更新
         """
-        # Billing1: free → past_due
+        # Billing1: free → trial_expired
         office1 = await office_factory(session=db_session, is_test_data=True)
         await db_session.commit()
         billing1 = await crud.billing.create_for_office(
@@ -330,7 +431,49 @@ class TestTrialExpirationCheck:
         # 検証
         await db_session.refresh(billing1)
         await db_session.refresh(billing2)
-        assert billing1.billing_status == BillingStatus.past_due
+        assert billing1.billing_status == BillingStatus.trial_expired
+        assert billing2.billing_status == BillingStatus.active
+        assert_updated_at_least(expired_count, 2)
+
+    async def test_mixed_statuses_batch_update_uses_trial_expired(
+        self,
+        db_session,
+        office_factory
+    ):
+        """
+        新仕様: free期限切れはtrial_expired、early_payment期限切れはactiveへ更新される。
+        """
+        office1 = await office_factory(session=db_session, is_test_data=True)
+        await db_session.commit()
+        billing1 = await crud.billing.create_for_office(
+            db=db_session,
+            office_id=office1.id,
+            trial_days=180
+        )
+        await db_session.commit()
+        billing1.trial_end_date = datetime.now(timezone.utc) - timedelta(days=1)
+        billing1.billing_status = BillingStatus.free
+        billing1.stripe_subscription_id = None
+
+        office2 = await office_factory(session=db_session, is_test_data=True)
+        await db_session.commit()
+        billing2 = await crud.billing.create_for_office(
+            db=db_session,
+            office_id=office2.id,
+            trial_days=180
+        )
+        await db_session.commit()
+        billing2.trial_end_date = datetime.now(timezone.utc) - timedelta(days=2)
+        billing2.billing_status = BillingStatus.early_payment
+        billing2.stripe_subscription_id = "sub_test_batch_new_status"
+
+        await db_session.commit()
+
+        expired_count = await check_trial_expiration(db=db_session)
+
+        await db_session.refresh(billing1)
+        await db_session.refresh(billing2)
+        assert billing1.billing_status == BillingStatus.trial_expired
         assert billing2.billing_status == BillingStatus.active
         assert_updated_at_least(expired_count, 2)
 


### PR DESCRIPTION
## Summary
- add trial_expired and payment_failed billing statuses with migration SQL
- refine Stripe webhook status transitions for subscription created/updated/deleted and invoice payment failures
- align backend access control and scheduled billing checks with the new status semantics
- add focused backend tests for billing status helpers, webhooks, scheduled cancellation, and billing checks

## Tests
- docker exec keikakun_app-backend-1 pytest tests/services/test_billing_status_helpers.py tests/services/test_billing_service.py tests/services/test_billing_canceling.py tests/tasks/test_billing_check.py tests/scheduler/test_billing_scheduler.py -q
  - 73 passed in 473.87s