### PR TITLE
test: run billing scheduler start tests in event loop

### DIFF
--- a/tests/scheduler/test_billing_scheduler.py
+++ b/tests/scheduler/test_billing_scheduler.py
@@ -1,4 +1,5 @@
 from apscheduler.schedulers.asyncio import AsyncIOScheduler
+import pytest
 
 import app.main as main
 import app.scheduler.billing_scheduler as billing_scheduler_module
@@ -12,7 +13,8 @@ class TestBillingScheduler:
         """
         assert main.billing_scheduler is billing_scheduler_module
 
-    def test_start_registers_billing_jobs(self, monkeypatch):
+    @pytest.mark.asyncio
+    async def test_start_registers_billing_jobs(self, monkeypatch):
         """start() wrapper が課金バッチ用 job を登録することを検証。"""
         scheduler = AsyncIOScheduler()
         monkeypatch.setattr(billing_scheduler_module, "billing_scheduler", scheduler)
@@ -29,7 +31,8 @@ class TestBillingScheduler:
         finally:
             billing_scheduler_module.shutdown()
 
-    def test_multiple_start_calls_do_not_duplicate_jobs(self, monkeypatch):
+    @pytest.mark.asyncio
+    async def test_multiple_start_calls_do_not_duplicate_jobs(self, monkeypatch):
         """start() を複数回呼んでも job が重複しないことを検証。"""
         scheduler = AsyncIOScheduler()
         monkeypatch.setattr(billing_scheduler_module, "billing_scheduler", scheduler)


### PR DESCRIPTION
  tests/scheduler/test_billing_scheduler.py の2テストが同期関数のまま AsyncIOScheduler.start() を呼んでいました。
  APScheduler の AsyncIOScheduler は start 時に asyncio event loop を取得しますが、CI/本番テスト環境では MainThread に
  current event loop が存在しないため、次のエラーになっています。

  RuntimeError: There is no current event loop in thread 'MainThread'.

  実アプリでは app.main.startup_event() が async context で呼ばれるため、running event loop があり、この問題は主にテストの
  呼び出し方で発生します。

  対応:

  - 該当2テストに pytest.mark.asyncio を付与
  - async def 化して、event loop 上で billing_scheduler_module.start() を呼ぶように修正