### PR TITLE
[codex] fix backend CSRF billing and migration safeguards

### DIFF
--- a/app/api/deps.py
+++ b/app/api/deps.py
@@ -228,6 +228,20 @@ async def require_owner(
     return current_staff
 
 
+async def require_owner_with_office(
+    current_staff: Staff = Depends(get_current_user_with_office)
+) -> Staff:
+    """
+    Owner のみアクセス可能で、office_associations も必要なendpoint向け。
+    """
+    if current_staff.role != StaffRole.owner:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail=ja.PERM_OWNER_REQUIRED
+        )
+    return current_staff
+
+
 async def require_app_admin(
     current_staff: Staff = Depends(get_current_user_minimal)
 ) -> Staff:
@@ -246,6 +260,7 @@ async def require_app_admin(
 async def check_employee_restriction(
     db: AsyncSession,
     current_staff: Staff,
+    office_id: Optional[uuid.UUID],
     resource_type: "ResourceType",
     action_type: "ActionType",
     resource_id: Optional[uuid.UUID] = None,
@@ -259,6 +274,7 @@ async def check_employee_restriction(
     Args:
         db: データベースセッション
         current_staff: 現在のスタッフ
+        office_id: 操作対象の事業所ID
         resource_type: リソースタイプ（welfare_recipient, support_plan_cycle, etc.）
         action_type: アクションタイプ（create, update, delete）
         resource_id: リソースID（updateまたはdeleteの場合）
@@ -274,23 +290,6 @@ async def check_employee_restriction(
     # Manager/Ownerは制限なし
     if current_staff.role in [StaffRole.manager, StaffRole.owner]:
         return None
-
-    # Employeeの場合、リクエストを作成
-    # office_idを取得（office_associations経由）
-    office_id = None
-    if current_staff.office:
-        office_id = current_staff.office.id
-    elif current_staff.office_associations:
-        # プライマリ事業所を優先
-        primary_office = next(
-            (assoc.office for assoc in current_staff.office_associations if assoc.is_primary),
-            None
-        )
-        if primary_office:
-            office_id = primary_office.id
-        elif current_staff.office_associations:
-            # プライマリがなければ最初の事業所
-            office_id = current_staff.office_associations[0].office_id
 
     if not office_id:
         raise HTTPException(

--- a/app/api/v1/endpoints/billing.py
+++ b/app/api/v1/endpoints/billing.py
@@ -124,7 +124,7 @@ async def get_billing_status(
 @router.post("/create-checkout-session")
 async def create_checkout_session(
     db: Annotated[AsyncSession, Depends(deps.get_db)],
-    current_user: Annotated[Staff, Depends(deps.require_owner)]
+    current_user: Annotated[Staff, Depends(deps.require_owner_with_office)]
 ):
     """
     Stripe Checkout Session作成API（サービス層利用版）
@@ -205,7 +205,7 @@ async def create_checkout_session(
 @router.post("/create-portal-session")
 async def create_portal_session(
     db: Annotated[AsyncSession, Depends(deps.get_db)],
-    current_user: Annotated[Staff, Depends(deps.require_owner)]
+    current_user: Annotated[Staff, Depends(deps.require_owner_with_office)]
 ):
     """
     Stripe Customer Portal Session作成API
@@ -249,8 +249,28 @@ async def create_portal_session(
 
         return {"url": portal_session.url}
 
+    except stripe.error.StripeError as e:
+        logger.error(
+            "Stripe Customer Portal Session creation failed: "
+            "stripe_error_type=%s, billing_id=%s, office_id=%s, stripe_customer_id=%s",
+            type(e).__name__,
+            billing.id,
+            office_id,
+            billing.stripe_customer_id,
+        )
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail=ja.BILLING_PORTAL_SESSION_FAILED
+        )
     except Exception as e:
-        logger.error("Stripe Customer Portal Session作成エラー: %s", type(e).__name__)
+        logger.error(
+            "Stripe Customer Portal Session creation failed: "
+            "error_type=%s, billing_id=%s, office_id=%s, has_stripe_customer_id=%s",
+            type(e).__name__,
+            billing.id,
+            office_id,
+            bool(billing.stripe_customer_id),
+        )
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail=ja.BILLING_PORTAL_SESSION_FAILED

--- a/app/api/v1/endpoints/support_plan_statuses.py
+++ b/app/api/v1/endpoints/support_plan_statuses.py
@@ -78,6 +78,7 @@ async def update_next_plan_start_date(
     employee_request = await deps.check_employee_restriction(
         db=db,
         current_staff=current_user,
+        office_id=recipient_office_assoc.office_id,
         resource_type=ResourceType.support_plan_status,
         action_type=ActionType.update,
         resource_id=None,  # status_id は int なので None

--- a/app/api/v1/endpoints/welfare_recipients.py
+++ b/app/api/v1/endpoints/welfare_recipients.py
@@ -63,6 +63,7 @@ async def create_welfare_recipient(
         employee_request = await deps.check_employee_restriction(
             db=db,
             current_staff=current_staff,
+            office_id=office_id,
             resource_type=ResourceType.welfare_recipient,
             action_type=ActionType.create,
             request_data=registration_data.model_dump(mode='json')
@@ -282,6 +283,7 @@ async def update_welfare_recipient(
     employee_request = await deps.check_employee_restriction(
         db=db,
         current_staff=current_staff,
+        office_id=office_id,
         resource_type=ResourceType.welfare_recipient,
         action_type=ActionType.update,
         resource_id=recipient_id,
@@ -355,6 +357,7 @@ async def delete_welfare_recipient(
     employee_request = await deps.check_employee_restriction(
         db=db,
         current_staff=current_staff,
+        office_id=office_id,
         resource_type=ResourceType.welfare_recipient,
         action_type=ActionType.delete,
         resource_id=recipient_id

--- a/app/main.py
+++ b/app/main.py
@@ -48,6 +48,12 @@ app.add_exception_handler(RateLimitExceeded, _rate_limit_exceeded_handler)
 CSRF_EXEMPT_PATHS = {
     "/api/v1/csrf-token",
     "/api/v1/csrf-token/",
+    "/api/v1/auth/token",
+    "/api/v1/auth/token/",
+    "/api/v1/auth/token/verify-mfa",
+    "/api/v1/auth/token/verify-mfa/",
+    "/api/v1/auth/mfa/first-time-verify",
+    "/api/v1/auth/mfa/first-time-verify/",
     "/api/v1/auth/refresh-token",
     "/api/v1/auth/refresh-token/",
     "/api/v1/billing/webhook",

--- a/cloudbuild.yml
+++ b/cloudbuild.yml
@@ -22,7 +22,25 @@ steps:
     - '--all-tags'
     - 'asia-northeast1-docker.pkg.dev/$PROJECT_ID/k-back-repo/k-back'
 
-# 3. プッシュしたイメージを使ってCloud Runにデプロイするステップ（commit hashタグで明示的にバージョン管理）
+# 3. 本番DBがbaseline以降としてAlembic管理されていることを確認する
+- name: 'asia-northeast1-docker.pkg.dev/$PROJECT_ID/k-back-repo/k-back:$SHORT_SHA'
+  entrypoint: python
+  env:
+    - 'DATABASE_URL=${_PROD_DATABASE_URL}'
+    - 'ALEMBIC_BASELINE_REVISION=baseline_20260701'
+  args:
+    - 'scripts/alembic_baseline_guard.py'
+
+# 4. Cloud Runに反映する前に、本番DBへAlembic migrationを適用する
+- name: 'asia-northeast1-docker.pkg.dev/$PROJECT_ID/k-back-repo/k-back:$SHORT_SHA'
+  entrypoint: alembic
+  env:
+    - 'DATABASE_URL=${_PROD_DATABASE_URL}'
+  args:
+    - 'upgrade'
+    - 'head'
+
+# 5. プッシュしたイメージを使ってCloud Runにデプロイするステップ（commit hashタグで明示的にバージョン管理）
 - name: 'gcr.io/google.com/cloudsdktool/cloud-sdk'
   entrypoint: gcloud
   args:

--- a/migrations/versions/a1b2c3d4e5f6_add_dashboard_performance_indexes.py
+++ b/migrations/versions/a1b2c3d4e5f6_add_dashboard_performance_indexes.py
@@ -1,6 +1,6 @@
 """Add dashboard performance indexes
 
-Revision ID: a1b2c3d4e5f6
+Revision ID: a1b2c3d4e5f8
 Revises: z8a9b0c1d2e3
 Create Date: 2026-02-16
 
@@ -35,7 +35,7 @@ import sqlalchemy as sa
 
 
 # revision identifiers, used by Alembic.
-revision: str = 'a1b2c3d4e5f6'
+revision: str = 'a1b2c3d4e5f8'
 down_revision: Union[str, None] = 'z8a9b0c1d2e3'
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None

--- a/migrations/versions/a1b2c3d4e5f6_add_is_test_data_flag_to_all_tables.py
+++ b/migrations/versions/a1b2c3d4e5f6_add_is_test_data_flag_to_all_tables.py
@@ -1,6 +1,6 @@
 """Add is_test_data flag to all test-related tables
 
-Revision ID: a1b2c3d4e5f6
+Revision ID: a1b2c3d4e5f7
 Revises: t5u6v7w8x9y0
 Create Date: 2025-11-19 10:00:00.000000
 
@@ -10,7 +10,7 @@ import sqlalchemy as sa
 
 
 # revision identifiers, used by Alembic.
-revision = 'a1b2c3d4e5f6'
+revision = 'a1b2c3d4e5f7'
 down_revision = 't5u6v7w8x9y0'
 branch_labels = None
 depends_on = None

--- a/migrations/versions/baseline_20260701_current_schema.py
+++ b/migrations/versions/baseline_20260701_current_schema.py
@@ -1,0 +1,39 @@
+"""baseline current schema for Alembic restart
+
+Revision ID: baseline_20260701
+Revises: a1b2c3d4e5f6, a1b2c3d4e5f7, a1b2c3d4e5f8, b0c1d2e3f4g5, n3o4p5q6r7s8, q8r9s0t1u2v3
+Create Date: 2026-07-01
+
+This revision is a no-op baseline marker.
+
+The existing NeonDB branches were mostly managed with manual SQL before this
+point, and their alembic_version state is not a reliable representation of the
+actual schema. Do not run historical migrations against existing databases to
+reach this revision. Existing databases should be schema-verified first, then
+stamped to this revision only after approval.
+"""
+from typing import Sequence, Union
+
+
+# revision identifiers, used by Alembic.
+revision: str = "baseline_20260701"
+down_revision: Union[str, tuple[str, ...], None] = (
+    "a1b2c3d4e5f6",
+    "a1b2c3d4e5f7",
+    "a1b2c3d4e5f8",
+    "b0c1d2e3f4g5",
+    "n3o4p5q6r7s8",
+    "q8r9s0t1u2v3",
+)
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """No-op: baseline marker for existing verified schemas."""
+    pass
+
+
+def downgrade() -> None:
+    """No-op: do not use this revision to roll back schema objects."""
+    pass

--- a/migrations/versions/byddyrpnnpk5_add_cycle_number.py
+++ b/migrations/versions/byddyrpnnpk5_add_cycle_number.py
@@ -1,7 +1,7 @@
 """add_cycle_number
 
 Revision ID: byddyrpnnpk5
-Revises: su6cug3oavuk
+Revises: 001_create_mfa
 Create Date: 2025-10-21 00:00:02
 
 """
@@ -13,7 +13,7 @@ import sqlalchemy as sa
 
 # revision identifiers, used by Alembic.
 revision: str = 'byddyrpnnpk5'
-down_revision: Union[str, None] = 'su6cug3oavuk'
+down_revision: Union[str, None] = '001_create_mfa'
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 

--- a/migrations/versions/r3s4t5u6v7w8_add_password_reset_tokens.py
+++ b/migrations/versions/r3s4t5u6v7w8_add_password_reset_tokens.py
@@ -1,7 +1,7 @@
 """add password reset tokens table
 
 Revision ID: r3s4t5u6v7w8
-Revises: a1b2c3d4e5f6
+Revises: q2r3s4t5u6v7
 Create Date: 2025-01-20 10:00:00.000000
 
 """
@@ -11,7 +11,7 @@ from sqlalchemy.dialects import postgresql
 
 # revision identifiers, used by Alembic.
 revision = 'r3s4t5u6v7w8'
-down_revision = 'a1b2c3d4e5f6'
+down_revision = 'q2r3s4t5u6v7'
 branch_labels = None
 depends_on = None
 

--- a/scripts/alembic_baseline_guard.py
+++ b/scripts/alembic_baseline_guard.py
@@ -1,0 +1,103 @@
+"""Verify that the target DB is already managed from the Alembic baseline."""
+
+from __future__ import annotations
+
+import os
+import sys
+from typing import Iterable
+
+from alembic.config import Config
+from alembic.runtime.migration import MigrationContext
+from alembic.script import ScriptDirectory
+from sqlalchemy import create_engine
+
+
+BASELINE_REVISION = "baseline_20260701"
+
+
+def normalize_database_url(database_url: str) -> str:
+    """Convert async SQLAlchemy URLs to a sync driver URL for Alembic checks."""
+    return database_url.replace("postgresql+asyncpg://", "postgresql://", 1)
+
+
+def revision_includes_baseline(
+    script: ScriptDirectory,
+    current_revision: str,
+    baseline_revision: str = BASELINE_REVISION,
+) -> bool:
+    if current_revision == baseline_revision:
+        return True
+
+    try:
+        revisions = script.iterate_revisions(current_revision, baseline_revision)
+        return any(revision.revision == baseline_revision for revision in revisions)
+    except Exception:
+        return False
+
+
+def validate_current_heads(
+    current_heads: Iterable[str],
+    script: ScriptDirectory,
+    baseline_revision: str = BASELINE_REVISION,
+) -> tuple[str, ...]:
+    heads = tuple(current_heads)
+    if not heads:
+        raise RuntimeError(
+            "Alembic current revision is empty. "
+            f"Stamp the verified DB to {baseline_revision} before running CD."
+        )
+
+    invalid_heads = [
+        revision
+        for revision in heads
+        if not revision_includes_baseline(script, revision, baseline_revision)
+    ]
+    if invalid_heads:
+        invalid = ", ".join(invalid_heads)
+        raise RuntimeError(
+            "Alembic baseline check failed. "
+            f"Current revision(s) [{invalid}] are not at or after "
+            f"{baseline_revision}. Verify the schema and run one-time "
+            f"`alembic stamp {baseline_revision}` before enabling CD migration."
+        )
+
+    return heads
+
+
+def get_current_heads(database_url: str, alembic_config_path: str) -> tuple[str, ...]:
+    engine = create_engine(normalize_database_url(database_url))
+    with engine.connect() as connection:
+        context = MigrationContext.configure(connection)
+        return tuple(context.get_current_heads())
+
+
+def main() -> int:
+    database_url = os.getenv("DATABASE_URL")
+    if not database_url:
+        print("DATABASE_URL is required for Alembic baseline check.", file=sys.stderr)
+        return 2
+
+    baseline_revision = os.getenv("ALEMBIC_BASELINE_REVISION", BASELINE_REVISION)
+    alembic_config_path = os.getenv("ALEMBIC_CONFIG", "alembic.ini")
+    script = ScriptDirectory.from_config(Config(alembic_config_path))
+
+    try:
+        current_heads = get_current_heads(database_url, alembic_config_path)
+        validated_heads = validate_current_heads(
+            current_heads,
+            script,
+            baseline_revision,
+        )
+    except Exception as exc:
+        print(str(exc), file=sys.stderr)
+        return 1
+
+    print(
+        "Alembic baseline check passed: "
+        f"current={','.join(validated_heads)} baseline={baseline_revision}"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/cleanup_e2e_staffs_and_offices.py
+++ b/scripts/cleanup_e2e_staffs_and_offices.py
@@ -1,0 +1,176 @@
+"""
+Clean up E2E staffs and their related offices.
+
+Default behavior is a dry run. Add --execute to run the destructive SQL.
+
+Targets:
+    - staffs.email contains both "e2e_staff" and "@example.com"
+    - offices.name contains "E2Eテスト事務所"
+
+Usage:
+    TEST_DATABASE_URL=... python scripts/cleanup_e2e_staffs_and_offices.py
+    TEST_DATABASE_URL=... python scripts/cleanup_e2e_staffs_and_offices.py --execute
+"""
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+from pathlib import Path
+
+from sqlalchemy import create_engine, text
+
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+SQL_PATH = SCRIPT_DIR / "cleanup_e2e_staffs_and_offices.sql"
+
+PREVIEW_SQL = """
+WITH target_staffs AS (
+    SELECT id, email
+    FROM staffs
+    WHERE email ILIKE '%e2e_staff%'
+      AND email ILIKE '%@example.com%'
+),
+target_offices AS (
+    SELECT DISTINCT o.id, o.name
+    FROM offices o
+    WHERE o.name LIKE '%E2Eテスト事務所%'
+       OR o.created_by IN (SELECT id FROM target_staffs)
+       OR o.last_modified_by IN (SELECT id FROM target_staffs)
+       OR o.deleted_by IN (SELECT id FROM target_staffs)
+       OR EXISTS (
+            SELECT 1
+            FROM office_staffs os
+            WHERE os.office_id = o.id
+              AND os.staff_id IN (SELECT id FROM target_staffs)
+       )
+),
+target_welfare_recipients AS (
+    SELECT DISTINCT owr.welfare_recipient_id AS id
+    FROM office_welfare_recipients owr
+    WHERE owr.office_id IN (SELECT id FROM target_offices)
+      AND NOT EXISTS (
+          SELECT 1
+          FROM office_welfare_recipients other_owr
+          WHERE other_owr.welfare_recipient_id = owr.welfare_recipient_id
+            AND other_owr.office_id NOT IN (SELECT id FROM target_offices)
+      )
+),
+target_support_plan_cycles AS (
+    SELECT DISTINCT spc.id
+    FROM support_plan_cycles spc
+    WHERE spc.office_id IN (SELECT id FROM target_offices)
+       OR spc.welfare_recipient_id IN (SELECT id FROM target_welfare_recipients)
+)
+SELECT 'staffs' AS table_name, count(*) AS target_count FROM target_staffs
+UNION ALL
+SELECT 'offices', count(*) FROM target_offices
+UNION ALL
+SELECT 'welfare_recipients', count(*) FROM target_welfare_recipients
+UNION ALL
+SELECT 'support_plan_cycles', count(*) FROM target_support_plan_cycles
+ORDER BY table_name;
+"""
+
+
+def normalize_database_url(url: str) -> str:
+    return url.replace("postgresql+psycopg://", "postgresql://", 1).replace(
+        "postgresql+asyncpg://", "postgresql://", 1
+    )
+
+
+def get_database_url(env_name: str) -> str:
+    database_url = os.getenv(env_name)
+    if not database_url:
+        print(f"ERROR: {env_name} is not set", file=sys.stderr)
+        sys.exit(1)
+    return normalize_database_url(database_url)
+
+
+def verify_database_url(database_url: str, allow_production_keywords: bool) -> None:
+    if allow_production_keywords:
+        return
+
+    production_keywords = ("prod", "production", "live")
+    found = [keyword for keyword in production_keywords if keyword in database_url.lower()]
+    if found:
+        print("ERROR: database URL looks production-like.", file=sys.stderr)
+        print(f"Matched keywords: {', '.join(found)}", file=sys.stderr)
+        print("Pass --allow-production-keywords only if you are certain.", file=sys.stderr)
+        sys.exit(1)
+
+
+def confirm_execution(skip_confirmation: bool) -> None:
+    if skip_confirmation:
+        return
+
+    print()
+    print("This will DELETE E2E staffs/offices and related rows.")
+    response = input("Type DELETE E2E DATA to continue: ")
+    if response != "DELETE E2E DATA":
+        print("Cancelled.")
+        sys.exit(0)
+
+
+def print_preview(engine) -> None:
+    with engine.connect() as connection:
+        rows = connection.execute(text(PREVIEW_SQL)).mappings().all()
+
+    print("Dry-run target counts:")
+    for row in rows:
+        print(f"  {row['table_name']}: {row['target_count']}")
+
+
+def execute_cleanup(engine) -> None:
+    sql = SQL_PATH.read_text(encoding="utf-8")
+    with engine.connect().execution_options(isolation_level="AUTOCOMMIT") as connection:
+        connection.exec_driver_sql(sql)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--database-url-env",
+        default="TEST_DATABASE_URL",
+        help="Environment variable containing the database URL. Defaults to TEST_DATABASE_URL.",
+    )
+    parser.add_argument(
+        "--execute",
+        action="store_true",
+        help="Run the destructive cleanup. Without this flag only target counts are shown.",
+    )
+    parser.add_argument(
+        "--yes",
+        action="store_true",
+        help="Skip the interactive confirmation prompt when used with --execute.",
+    )
+    parser.add_argument(
+        "--allow-production-keywords",
+        action="store_true",
+        help="Allow database URLs containing production-like keywords.",
+    )
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    database_url = get_database_url(args.database_url_env)
+    verify_database_url(database_url, args.allow_production_keywords)
+
+    engine = create_engine(database_url, echo=False)
+    try:
+        print_preview(engine)
+        if not args.execute:
+            print()
+            print("No rows were deleted. Re-run with --execute to apply cleanup.")
+            return
+
+        confirm_execution(args.yes)
+        execute_cleanup(engine)
+        print("Cleanup completed.")
+    finally:
+        engine.dispose()
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/cleanup_e2e_staffs_and_offices.sql
+++ b/scripts/cleanup_e2e_staffs_and_offices.sql
@@ -1,0 +1,378 @@
+-- E2E test staff and office cleanup.
+--
+-- Targets:
+--   - staffs.email contains both "e2e_staff" and "@example.com"
+--   - offices.name contains "E2Eテスト事務所"
+--   - offices directly tied to target staffs through created_by/last_modified_by/deleted_by/office_staffs
+--
+-- Run with:
+--   psql "$TEST_DATABASE_URL" -f k_back/scripts/cleanup_e2e_staffs_and_offices.sql
+
+BEGIN;
+
+DO $$
+DECLARE
+    v_count integer;
+BEGIN
+    CREATE TEMP TABLE _e2e_staff_ids ON COMMIT DROP AS
+    SELECT DISTINCT s.id
+    FROM staffs s
+    WHERE s.email ILIKE '%e2e_staff%'
+      AND s.email ILIKE '%@example.com%';
+
+    CREATE TEMP TABLE _e2e_office_ids ON COMMIT DROP AS
+    SELECT DISTINCT o.id
+    FROM offices o
+    WHERE o.name LIKE '%E2Eテスト事務所%'
+       OR o.created_by IN (SELECT id FROM _e2e_staff_ids)
+       OR o.last_modified_by IN (SELECT id FROM _e2e_staff_ids)
+       OR o.deleted_by IN (SELECT id FROM _e2e_staff_ids)
+       OR EXISTS (
+            SELECT 1
+            FROM office_staffs os
+            WHERE os.office_id = o.id
+              AND os.staff_id IN (SELECT id FROM _e2e_staff_ids)
+       );
+
+    CREATE TEMP TABLE _e2e_welfare_recipient_ids ON COMMIT DROP AS
+    SELECT DISTINCT owr.welfare_recipient_id AS id
+    FROM office_welfare_recipients owr
+    WHERE owr.office_id IN (SELECT id FROM _e2e_office_ids)
+      AND NOT EXISTS (
+          SELECT 1
+          FROM office_welfare_recipients other_owr
+          WHERE other_owr.welfare_recipient_id = owr.welfare_recipient_id
+            AND other_owr.office_id NOT IN (SELECT id FROM _e2e_office_ids)
+      );
+
+    CREATE TEMP TABLE _e2e_support_plan_cycle_ids ON COMMIT DROP AS
+    SELECT DISTINCT spc.id
+    FROM support_plan_cycles spc
+    WHERE spc.office_id IN (SELECT id FROM _e2e_office_ids)
+       OR spc.welfare_recipient_id IN (SELECT id FROM _e2e_welfare_recipient_ids);
+
+    CREATE TEMP TABLE _e2e_support_plan_status_ids ON COMMIT DROP AS
+    SELECT DISTINCT sps.id
+    FROM support_plan_statuses sps
+    WHERE sps.office_id IN (SELECT id FROM _e2e_office_ids)
+       OR sps.welfare_recipient_id IN (SELECT id FROM _e2e_welfare_recipient_ids)
+       OR sps.plan_cycle_id IN (SELECT id FROM _e2e_support_plan_cycle_ids);
+
+    CREATE TEMP TABLE _e2e_message_ids ON COMMIT DROP AS
+    SELECT DISTINCT m.id
+    FROM messages m
+    WHERE m.office_id IN (SELECT id FROM _e2e_office_ids)
+       OR m.sender_staff_id IN (SELECT id FROM _e2e_staff_ids);
+
+    CREATE TEMP TABLE _e2e_calendar_event_series_ids ON COMMIT DROP AS
+    SELECT DISTINCT ces.id
+    FROM calendar_event_series ces
+    WHERE ces.office_id IN (SELECT id FROM _e2e_office_ids)
+       OR ces.welfare_recipient_id IN (SELECT id FROM _e2e_welfare_recipient_ids)
+       OR ces.support_plan_cycle_id IN (SELECT id FROM _e2e_support_plan_cycle_ids)
+       OR ces.support_plan_status_id IN (SELECT id FROM _e2e_support_plan_status_ids);
+
+    CREATE TEMP TABLE _e2e_billing_ids ON COMMIT DROP AS
+    SELECT DISTINCT b.id
+    FROM billings b
+    WHERE b.office_id IN (SELECT id FROM _e2e_office_ids);
+
+    RAISE NOTICE 'E2E cleanup targets: staffs=%, offices=%, welfare_recipients=%, support_plan_cycles=%',
+        (SELECT count(*) FROM _e2e_staff_ids),
+        (SELECT count(*) FROM _e2e_office_ids),
+        (SELECT count(*) FROM _e2e_welfare_recipient_ids),
+        (SELECT count(*) FROM _e2e_support_plan_cycle_ids);
+
+    UPDATE webhook_events
+    SET billing_id = NULL
+    WHERE billing_id IN (SELECT id FROM _e2e_billing_ids);
+    GET DIAGNOSTICS v_count = ROW_COUNT;
+    RAISE NOTICE 'webhook_events.billing_id nulled: %', v_count;
+
+    UPDATE webhook_events
+    SET office_id = NULL
+    WHERE office_id IN (SELECT id FROM _e2e_office_ids);
+    GET DIAGNOSTICS v_count = ROW_COUNT;
+    RAISE NOTICE 'webhook_events.office_id nulled: %', v_count;
+
+    UPDATE audit_logs
+    SET staff_id = NULL
+    WHERE staff_id IN (SELECT id FROM _e2e_staff_ids);
+    GET DIAGNOSTICS v_count = ROW_COUNT;
+    RAISE NOTICE 'audit_logs.staff_id nulled: %', v_count;
+
+    UPDATE audit_logs
+    SET office_id = NULL
+    WHERE office_id IN (SELECT id FROM _e2e_office_ids);
+    GET DIAGNOSTICS v_count = ROW_COUNT;
+    RAISE NOTICE 'audit_logs.office_id nulled: %', v_count;
+
+    UPDATE message_audit_logs
+    SET staff_id = NULL
+    WHERE staff_id IN (SELECT id FROM _e2e_staff_ids);
+    GET DIAGNOSTICS v_count = ROW_COUNT;
+    RAISE NOTICE 'message_audit_logs.staff_id nulled: %', v_count;
+
+    UPDATE message_audit_logs
+    SET message_id = NULL
+    WHERE message_id IN (SELECT id FROM _e2e_message_ids);
+    GET DIAGNOSTICS v_count = ROW_COUNT;
+    RAISE NOTICE 'message_audit_logs.message_id nulled: %', v_count;
+
+    UPDATE password_reset_audit_logs
+    SET staff_id = NULL
+    WHERE staff_id IN (SELECT id FROM _e2e_staff_ids);
+    GET DIAGNOSTICS v_count = ROW_COUNT;
+    RAISE NOTICE 'password_reset_audit_logs.staff_id nulled: %', v_count;
+
+    UPDATE office_audit_logs
+    SET staff_id = NULL
+    WHERE staff_id IN (SELECT id FROM _e2e_staff_ids);
+    GET DIAGNOSTICS v_count = ROW_COUNT;
+    RAISE NOTICE 'office_audit_logs.staff_id nulled: %', v_count;
+
+    UPDATE inquiry_details
+    SET assigned_staff_id = NULL
+    WHERE assigned_staff_id IN (SELECT id FROM _e2e_staff_ids);
+    GET DIAGNOSTICS v_count = ROW_COUNT;
+    RAISE NOTICE 'inquiry_details.assigned_staff_id nulled: %', v_count;
+
+    UPDATE staffs
+    SET deleted_by = NULL
+    WHERE deleted_by IN (SELECT id FROM _e2e_staff_ids);
+    GET DIAGNOSTICS v_count = ROW_COUNT;
+    RAISE NOTICE 'staffs.deleted_by nulled: %', v_count;
+
+    UPDATE offices
+    SET deleted_by = NULL
+    WHERE deleted_by IN (SELECT id FROM _e2e_staff_ids);
+    GET DIAGNOSTICS v_count = ROW_COUNT;
+    RAISE NOTICE 'offices.deleted_by nulled: %', v_count;
+
+    DELETE FROM calendar_event_instances
+    WHERE event_series_id IN (SELECT id FROM _e2e_calendar_event_series_ids);
+    GET DIAGNOSTICS v_count = ROW_COUNT;
+    RAISE NOTICE 'calendar_event_instances deleted: %', v_count;
+
+    DELETE FROM calendar_events
+    WHERE office_id IN (SELECT id FROM _e2e_office_ids)
+       OR welfare_recipient_id IN (SELECT id FROM _e2e_welfare_recipient_ids)
+       OR support_plan_cycle_id IN (SELECT id FROM _e2e_support_plan_cycle_ids)
+       OR support_plan_status_id IN (SELECT id FROM _e2e_support_plan_status_ids);
+    GET DIAGNOSTICS v_count = ROW_COUNT;
+    RAISE NOTICE 'calendar_events deleted: %', v_count;
+
+    DELETE FROM calendar_event_series
+    WHERE id IN (SELECT id FROM _e2e_calendar_event_series_ids);
+    GET DIAGNOSTICS v_count = ROW_COUNT;
+    RAISE NOTICE 'calendar_event_series deleted: %', v_count;
+
+    DELETE FROM inquiry_details
+    WHERE message_id IN (SELECT id FROM _e2e_message_ids);
+    GET DIAGNOSTICS v_count = ROW_COUNT;
+    RAISE NOTICE 'inquiry_details deleted: %', v_count;
+
+    DELETE FROM message_recipients
+    WHERE message_id IN (SELECT id FROM _e2e_message_ids)
+       OR recipient_staff_id IN (SELECT id FROM _e2e_staff_ids);
+    GET DIAGNOSTICS v_count = ROW_COUNT;
+    RAISE NOTICE 'message_recipients deleted: %', v_count;
+
+    DELETE FROM messages
+    WHERE id IN (SELECT id FROM _e2e_message_ids);
+    GET DIAGNOSTICS v_count = ROW_COUNT;
+    RAISE NOTICE 'messages deleted: %', v_count;
+
+    DELETE FROM notices
+    WHERE office_id IN (SELECT id FROM _e2e_office_ids)
+       OR recipient_staff_id IN (SELECT id FROM _e2e_staff_ids);
+    GET DIAGNOSTICS v_count = ROW_COUNT;
+    RAISE NOTICE 'notices deleted: %', v_count;
+
+    DELETE FROM approval_requests
+    WHERE office_id IN (SELECT id FROM _e2e_office_ids)
+       OR requester_staff_id IN (SELECT id FROM _e2e_staff_ids)
+       OR reviewed_by_staff_id IN (SELECT id FROM _e2e_staff_ids);
+    GET DIAGNOSTICS v_count = ROW_COUNT;
+    RAISE NOTICE 'approval_requests deleted: %', v_count;
+
+    DELETE FROM employee_action_requests
+    WHERE office_id IN (SELECT id FROM _e2e_office_ids)
+       OR requester_staff_id IN (SELECT id FROM _e2e_staff_ids)
+       OR approved_by_staff_id IN (SELECT id FROM _e2e_staff_ids);
+    GET DIAGNOSTICS v_count = ROW_COUNT;
+    RAISE NOTICE 'employee_action_requests deleted: %', v_count;
+
+    DELETE FROM role_change_requests
+    WHERE office_id IN (SELECT id FROM _e2e_office_ids)
+       OR requester_staff_id IN (SELECT id FROM _e2e_staff_ids)
+       OR reviewed_by_staff_id IN (SELECT id FROM _e2e_staff_ids);
+    GET DIAGNOSTICS v_count = ROW_COUNT;
+    RAISE NOTICE 'role_change_requests deleted: %', v_count;
+
+    DELETE FROM push_subscriptions
+    WHERE staff_id IN (SELECT id FROM _e2e_staff_ids);
+    GET DIAGNOSTICS v_count = ROW_COUNT;
+    RAISE NOTICE 'push_subscriptions deleted: %', v_count;
+
+    DELETE FROM terms_agreements
+    WHERE staff_id IN (SELECT id FROM _e2e_staff_ids);
+    GET DIAGNOSTICS v_count = ROW_COUNT;
+    RAISE NOTICE 'terms_agreements deleted: %', v_count;
+
+    DELETE FROM email_change_requests
+    WHERE staff_id IN (SELECT id FROM _e2e_staff_ids);
+    GET DIAGNOSTICS v_count = ROW_COUNT;
+    RAISE NOTICE 'email_change_requests deleted: %', v_count;
+
+    DELETE FROM password_histories
+    WHERE staff_id IN (SELECT id FROM _e2e_staff_ids);
+    GET DIAGNOSTICS v_count = ROW_COUNT;
+    RAISE NOTICE 'password_histories deleted: %', v_count;
+
+    DELETE FROM password_reset_tokens
+    WHERE staff_id IN (SELECT id FROM _e2e_staff_ids);
+    GET DIAGNOSTICS v_count = ROW_COUNT;
+    RAISE NOTICE 'password_reset_tokens deleted: %', v_count;
+
+    DELETE FROM refresh_token_blacklist
+    WHERE staff_id IN (SELECT id FROM _e2e_staff_ids);
+    GET DIAGNOSTICS v_count = ROW_COUNT;
+    RAISE NOTICE 'refresh_token_blacklist deleted: %', v_count;
+
+    DELETE FROM mfa_backup_codes
+    WHERE staff_id IN (SELECT id FROM _e2e_staff_ids);
+    GET DIAGNOSTICS v_count = ROW_COUNT;
+    RAISE NOTICE 'mfa_backup_codes deleted: %', v_count;
+
+    DELETE FROM mfa_audit_logs
+    WHERE staff_id IN (SELECT id FROM _e2e_staff_ids);
+    GET DIAGNOSTICS v_count = ROW_COUNT;
+    RAISE NOTICE 'mfa_audit_logs deleted: %', v_count;
+
+    DELETE FROM staff_calendar_accounts
+    WHERE staff_id IN (SELECT id FROM _e2e_staff_ids);
+    GET DIAGNOSTICS v_count = ROW_COUNT;
+    RAISE NOTICE 'staff_calendar_accounts deleted: %', v_count;
+
+    DELETE FROM plan_deliverables
+    WHERE plan_cycle_id IN (SELECT id FROM _e2e_support_plan_cycle_ids)
+       OR uploaded_by IN (SELECT id FROM _e2e_staff_ids);
+    GET DIAGNOSTICS v_count = ROW_COUNT;
+    RAISE NOTICE 'plan_deliverables deleted: %', v_count;
+
+    DELETE FROM support_plan_statuses
+    WHERE id IN (SELECT id FROM _e2e_support_plan_status_ids);
+    GET DIAGNOSTICS v_count = ROW_COUNT;
+    RAISE NOTICE 'support_plan_statuses deleted: %', v_count;
+
+    DELETE FROM support_plan_cycles
+    WHERE id IN (SELECT id FROM _e2e_support_plan_cycle_ids);
+    GET DIAGNOSTICS v_count = ROW_COUNT;
+    RAISE NOTICE 'support_plan_cycles deleted: %', v_count;
+
+    DELETE FROM history_of_hospital_visits
+    WHERE medical_matters_id IN (
+        SELECT id FROM medical_matters
+        WHERE welfare_recipient_id IN (SELECT id FROM _e2e_welfare_recipient_ids)
+    );
+    GET DIAGNOSTICS v_count = ROW_COUNT;
+    RAISE NOTICE 'history_of_hospital_visits deleted: %', v_count;
+
+    DELETE FROM family_of_service_recipients
+    WHERE welfare_recipient_id IN (SELECT id FROM _e2e_welfare_recipient_ids);
+    GET DIAGNOSTICS v_count = ROW_COUNT;
+    RAISE NOTICE 'family_of_service_recipients deleted: %', v_count;
+
+    DELETE FROM welfare_services_used
+    WHERE welfare_recipient_id IN (SELECT id FROM _e2e_welfare_recipient_ids);
+    GET DIAGNOSTICS v_count = ROW_COUNT;
+    RAISE NOTICE 'welfare_services_used deleted: %', v_count;
+
+    DELETE FROM employment_related
+    WHERE welfare_recipient_id IN (SELECT id FROM _e2e_welfare_recipient_ids)
+       OR created_by_staff_id IN (SELECT id FROM _e2e_staff_ids);
+    GET DIAGNOSTICS v_count = ROW_COUNT;
+    RAISE NOTICE 'employment_related deleted: %', v_count;
+
+    DELETE FROM issue_analyses
+    WHERE welfare_recipient_id IN (SELECT id FROM _e2e_welfare_recipient_ids)
+       OR created_by_staff_id IN (SELECT id FROM _e2e_staff_ids);
+    GET DIAGNOSTICS v_count = ROW_COUNT;
+    RAISE NOTICE 'issue_analyses deleted: %', v_count;
+
+    DELETE FROM medical_matters
+    WHERE welfare_recipient_id IN (SELECT id FROM _e2e_welfare_recipient_ids);
+    GET DIAGNOSTICS v_count = ROW_COUNT;
+    RAISE NOTICE 'medical_matters deleted: %', v_count;
+
+    DELETE FROM disability_details
+    WHERE disability_status_id IN (
+        SELECT id FROM disability_statuses
+        WHERE welfare_recipient_id IN (SELECT id FROM _e2e_welfare_recipient_ids)
+    );
+    GET DIAGNOSTICS v_count = ROW_COUNT;
+    RAISE NOTICE 'disability_details deleted: %', v_count;
+
+    DELETE FROM disability_statuses
+    WHERE welfare_recipient_id IN (SELECT id FROM _e2e_welfare_recipient_ids);
+    GET DIAGNOSTICS v_count = ROW_COUNT;
+    RAISE NOTICE 'disability_statuses deleted: %', v_count;
+
+    DELETE FROM emergency_contacts
+    WHERE service_recipient_detail_id IN (
+        SELECT id FROM service_recipient_details
+        WHERE welfare_recipient_id IN (SELECT id FROM _e2e_welfare_recipient_ids)
+    );
+    GET DIAGNOSTICS v_count = ROW_COUNT;
+    RAISE NOTICE 'emergency_contacts deleted: %', v_count;
+
+    DELETE FROM service_recipient_details
+    WHERE welfare_recipient_id IN (SELECT id FROM _e2e_welfare_recipient_ids);
+    GET DIAGNOSTICS v_count = ROW_COUNT;
+    RAISE NOTICE 'service_recipient_details deleted: %', v_count;
+
+    DELETE FROM office_welfare_recipients
+    WHERE office_id IN (SELECT id FROM _e2e_office_ids)
+       OR welfare_recipient_id IN (SELECT id FROM _e2e_welfare_recipient_ids);
+    GET DIAGNOSTICS v_count = ROW_COUNT;
+    RAISE NOTICE 'office_welfare_recipients deleted: %', v_count;
+
+    DELETE FROM welfare_recipients
+    WHERE id IN (SELECT id FROM _e2e_welfare_recipient_ids);
+    GET DIAGNOSTICS v_count = ROW_COUNT;
+    RAISE NOTICE 'welfare_recipients deleted: %', v_count;
+
+    DELETE FROM office_calendar_accounts
+    WHERE office_id IN (SELECT id FROM _e2e_office_ids);
+    GET DIAGNOSTICS v_count = ROW_COUNT;
+    RAISE NOTICE 'office_calendar_accounts deleted: %', v_count;
+
+    DELETE FROM billings
+    WHERE id IN (SELECT id FROM _e2e_billing_ids);
+    GET DIAGNOSTICS v_count = ROW_COUNT;
+    RAISE NOTICE 'billings deleted: %', v_count;
+
+    DELETE FROM office_audit_logs
+    WHERE office_id IN (SELECT id FROM _e2e_office_ids);
+    GET DIAGNOSTICS v_count = ROW_COUNT;
+    RAISE NOTICE 'office_audit_logs deleted: %', v_count;
+
+    DELETE FROM office_staffs
+    WHERE office_id IN (SELECT id FROM _e2e_office_ids)
+       OR staff_id IN (SELECT id FROM _e2e_staff_ids);
+    GET DIAGNOSTICS v_count = ROW_COUNT;
+    RAISE NOTICE 'office_staffs deleted: %', v_count;
+
+    DELETE FROM offices
+    WHERE id IN (SELECT id FROM _e2e_office_ids);
+    GET DIAGNOSTICS v_count = ROW_COUNT;
+    RAISE NOTICE 'offices deleted: %', v_count;
+
+    DELETE FROM staffs
+    WHERE id IN (SELECT id FROM _e2e_staff_ids);
+    GET DIAGNOSTICS v_count = ROW_COUNT;
+    RAISE NOTICE 'staffs deleted: %', v_count;
+END $$;
+
+COMMIT;

--- a/tests/api/test_billing.py
+++ b/tests/api/test_billing.py
@@ -364,6 +364,176 @@ async def test_create_checkout_session_includes_metadata(
     assert call_kwargs['automatic_tax']['enabled'] is True
 
 
+async def test_create_portal_session_loads_office_associations_for_token_auth(
+    async_client: AsyncClient,
+    db_session: AsyncSession,
+    employee_user_factory,
+    mocker: MagicMock
+) -> None:
+    """
+    Token認証で取得したownerでもoffice associationを読み込んでPortal Sessionを作成できることを確認。
+    """
+    mocker.patch('app.api.v1.endpoints.billing.settings.STRIPE_SECRET_KEY', 'sk_test_12345')
+
+    unique_id = uuid4().hex
+    customer_id = f"cus_portal_{unique_id}"
+    portal_url = "https://billing.stripe.com/p/session/test"
+
+    mock_portal_create = mocker.patch('stripe.billing_portal.Session.create')
+    mock_portal_create.return_value = MagicMock(url=portal_url)
+
+    staff = await employee_user_factory(role=StaffRole.owner)
+    office_id = staff.office_associations[0].office_id
+
+    access_token_expires = timedelta(minutes=settings.ACCESS_TOKEN_EXPIRE_MINUTES)
+    access_token = create_access_token(str(staff.id), access_token_expires)
+
+    billing_data = BillingCreate(
+        office_id=office_id,
+        billing_status=BillingStatus.active,
+        stripe_customer_id=customer_id,
+        stripe_subscription_id=f"sub_portal_{unique_id}",
+        trial_start_date=datetime.now(timezone.utc) - timedelta(days=190),
+        trial_end_date=datetime.now(timezone.utc) - timedelta(days=10),
+        subscription_start_date=datetime.now(timezone.utc) - timedelta(days=10),
+        next_billing_date=datetime.now(timezone.utc) + timedelta(days=20),
+        current_plan_amount=6000
+    )
+    await crud.billing.create(db=db_session, obj_in=billing_data)
+    await db_session.commit()
+    db_session.expire_all()
+
+    response = await async_client.post(
+        "/api/v1/billing/create-portal-session",
+        headers={"Authorization": f"Bearer {access_token}"}
+    )
+
+    assert response.status_code == 200
+    assert response.json()["url"] == portal_url
+
+    mock_portal_create.assert_called_once()
+    call_kwargs = mock_portal_create.call_args.kwargs
+    assert call_kwargs["customer"] == customer_id
+    assert call_kwargs["return_url"] == f"{settings.FRONTEND_URL}/admin/plan"
+
+
+async def test_create_portal_session_loads_office_associations_for_cookie_auth(
+    async_client: AsyncClient,
+    db_session: AsyncSession,
+    employee_user_factory,
+    mocker: MagicMock
+) -> None:
+    """
+    Cookie認証でもPortal Session作成時にoffice associationのlazy loadが起きないことを確認。
+    """
+    mocker.patch('app.api.v1.endpoints.billing.settings.STRIPE_SECRET_KEY', 'sk_test_12345')
+
+    unique_id = uuid4().hex
+    customer_id = f"cus_portal_cookie_{unique_id}"
+    portal_url = "https://billing.stripe.com/p/session/cookie-test"
+
+    mock_portal_create = mocker.patch('stripe.billing_portal.Session.create')
+    mock_portal_create.return_value = MagicMock(url=portal_url)
+
+    staff = await employee_user_factory(role=StaffRole.owner)
+    staff_id = staff.id
+    office_id = staff.office_associations[0].office_id
+
+    billing_data = BillingCreate(
+        office_id=office_id,
+        billing_status=BillingStatus.active,
+        stripe_customer_id=customer_id,
+        stripe_subscription_id=f"sub_portal_cookie_{unique_id}",
+        trial_start_date=datetime.now(timezone.utc) - timedelta(days=190),
+        trial_end_date=datetime.now(timezone.utc) - timedelta(days=10),
+        subscription_start_date=datetime.now(timezone.utc) - timedelta(days=10),
+        next_billing_date=datetime.now(timezone.utc) + timedelta(days=20),
+        current_plan_amount=6000
+    )
+    await crud.billing.create(db=db_session, obj_in=billing_data)
+    await db_session.commit()
+    db_session.expire_all()
+
+    csrf_response = await async_client.get("/api/v1/csrf-token")
+    csrf_token = csrf_response.json()["csrf_token"]
+    access_token = create_access_token(
+        str(staff_id),
+        timedelta(minutes=settings.ACCESS_TOKEN_EXPIRE_MINUTES)
+    )
+    async_client.cookies.set("access_token", access_token)
+
+    response = await async_client.post(
+        "/api/v1/billing/create-portal-session",
+        headers={"X-CSRF-Token": csrf_token}
+    )
+
+    assert response.status_code == 200
+    assert response.json()["url"] == portal_url
+    mock_portal_create.assert_called_once()
+
+
+async def test_create_checkout_session_loads_office_associations_for_cookie_auth(
+    async_client: AsyncClient,
+    db_session: AsyncSession,
+    employee_user_factory,
+    mocker: MagicMock
+) -> None:
+    """
+    Cookie認証でもCheckout Session作成時にoffice associationのlazy loadが起きないことを確認。
+    """
+    mocker.patch('app.api.v1.endpoints.billing.settings.STRIPE_SECRET_KEY', 'sk_test_12345')
+    mocker.patch('app.api.v1.endpoints.billing.settings.STRIPE_PRICE_ID', 'price_test_12345')
+
+    unique_id = uuid4().hex
+    customer_id = f"cus_checkout_cookie_{unique_id}"
+    checkout_session_id = f"cs_checkout_cookie_{unique_id}"
+
+    mock_customer_create = mocker.patch('stripe.Customer.create')
+    mock_customer_create.return_value = MagicMock(id=customer_id)
+
+    mock_session_create = mocker.patch('stripe.checkout.Session.create')
+    mock_session_create.return_value = MagicMock(
+        id=checkout_session_id,
+        url='https://checkout.stripe.com/cookie-test'
+    )
+
+    staff = await employee_user_factory(role=StaffRole.owner)
+    staff_id = staff.id
+    office_id = staff.office_associations[0].office_id
+
+    billing = await crud.billing.create_for_office(
+        db=db_session,
+        office_id=office_id,
+        trial_days=180
+    )
+    billing_id = billing.id
+    await db_session.commit()
+    db_session.expire_all()
+
+    csrf_response = await async_client.get("/api/v1/csrf-token")
+    csrf_token = csrf_response.json()["csrf_token"]
+    access_token = create_access_token(
+        str(staff_id),
+        timedelta(minutes=settings.ACCESS_TOKEN_EXPIRE_MINUTES)
+    )
+    async_client.cookies.set("access_token", access_token)
+
+    response = await async_client.post(
+        "/api/v1/billing/create-checkout-session",
+        headers={"X-CSRF-Token": csrf_token}
+    )
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["session_id"] == checkout_session_id
+    assert data["url"] == "https://checkout.stripe.com/cookie-test"
+
+    mock_customer_create.assert_called_once()
+    mock_session_create.assert_called_once()
+    billing_after = await crud.billing.get(db=db_session, id=billing_id)
+    assert billing_after.stripe_customer_id == customer_id
+
+
 async def test_create_checkout_session_expired_free_without_customer_recovers_to_trial_expired(
     async_client: AsyncClient,
     db_session: AsyncSession,

--- a/tests/api/test_deps_permissions.py
+++ b/tests/api/test_deps_permissions.py
@@ -38,6 +38,11 @@ async def test_role_dependencies_use_minimal_current_user():
     assert _dependency_default(deps.require_app_admin, "current_staff") is deps.get_current_user_minimal
 
 
+async def test_owner_with_office_dependency_eager_loads_office():
+    """office associationを読むowner endpointはoffice付き依存を明示できる。"""
+    assert _dependency_default(deps.require_owner_with_office, "current_staff") is deps.get_current_user_with_office
+
+
 async def test_billing_dependency_requires_current_user_with_office():
     """課金チェックはoffice associationが必要なため、office付き依存を明示する。"""
     assert _dependency_default(deps.require_active_billing, "current_staff") is deps.get_current_user_with_office
@@ -232,6 +237,7 @@ async def test_check_employee_restriction_manager_returns_none(
     result = await check_employee_restriction(
         db=db_session,
         current_staff=manager,
+        office_id=office.id,
         resource_type=ResourceType.welfare_recipient,
         action_type=ActionType.create,
         request_data={"name": "テスト利用者"}
@@ -258,6 +264,7 @@ async def test_check_employee_restriction_owner_returns_none(
     result = await check_employee_restriction(
         db=db_session,
         current_staff=owner,
+        office_id=office.id,
         resource_type=ResourceType.welfare_recipient,
         action_type=ActionType.update,
         resource_id=uuid.uuid4(),
@@ -290,6 +297,7 @@ async def test_check_employee_restriction_employee_creates_request(
     result = await check_employee_restriction(
         db=db_session,
         current_staff=employee,
+        office_id=office.id,
         resource_type=ResourceType.welfare_recipient,
         action_type=ActionType.create,
         request_data=request_data
@@ -329,6 +337,7 @@ async def test_check_employee_restriction_employee_update_request(
     result = await check_employee_restriction(
         db=db_session,
         current_staff=employee,
+        office_id=office.id,
         resource_type=ResourceType.support_plan_cycle,
         action_type=ActionType.update,
         resource_id=resource_id,
@@ -365,6 +374,7 @@ async def test_check_employee_restriction_employee_delete_request(
     result = await check_employee_restriction(
         db=db_session,
         current_staff=employee,
+        office_id=office.id,
         resource_type=ResourceType.support_plan_status,
         action_type=ActionType.delete,
         resource_id=resource_id
@@ -378,3 +388,26 @@ async def test_check_employee_restriction_employee_delete_request(
     assert result.request_data["action_type"] == ActionType.delete.value
     # 削除時はoriginal_request_dataなし
     assert "original_request_data" not in result.request_data
+
+
+async def test_check_employee_restriction_employee_requires_explicit_office_id(
+    db_session: AsyncSession,
+    service_admin_user_factory,
+):
+    """Employee制限チェックはrelationshipをlazy loadせず、office_id未指定なら400を返す。"""
+    employee = await service_admin_user_factory(
+        email="employee-no-office-id@example.com",
+        role=StaffRole.employee
+    )
+
+    with pytest.raises(HTTPException) as exc_info:
+        await check_employee_restriction(
+            db=db_session,
+            current_staff=employee,
+            office_id=None,
+            resource_type=ResourceType.welfare_recipient,
+            action_type=ActionType.create,
+            request_data={"name": "新規利用者"}
+        )
+
+    assert exc_info.value.status_code == 400

--- a/tests/api/v1/test_csrf_protection.py
+++ b/tests/api/v1/test_csrf_protection.py
@@ -210,6 +210,37 @@ class TestCSRFProtection:
         assert "CSRF" in response.json().get("detail", "").upper()
 
     @pytest.mark.asyncio
+    async def test_login_is_not_blocked_by_csrf_when_stale_access_cookie_exists(
+        self,
+        async_client: AsyncClient,
+        db_session: AsyncSession,
+        owner_user_factory,
+    ):
+        """
+        ログインAPIは既存Cookieが残っていてもCSRFでは止めない。
+
+        退会済み判定など、ログイン本体のエラーメッセージを返す必要があるため。
+        """
+        owner = await owner_user_factory()
+        office = owner.office_associations[0].office
+        office.is_deleted = True
+        await db_session.commit()
+
+        stale_access_token = create_access_token(str(owner.id), timedelta(minutes=30))
+
+        response = await async_client.post(
+            "/api/v1/auth/token",
+            data={
+                "username": owner.email,
+                "password": "a-very-secure-password",
+            },
+            cookies={"access_token": stale_access_token},
+        )
+
+        assert response.status_code == 403
+        assert response.json()["detail"] == "所属事務所が退会済みのため、ログインできません"
+
+    @pytest.mark.asyncio
     async def test_get_requests_do_not_require_csrf(
         self,
         async_client: AsyncClient,

--- a/tests/api/v1/test_password_reset.py
+++ b/tests/api/v1/test_password_reset.py
@@ -758,12 +758,15 @@ class TestSessionInvalidation:
         await db_session.commit()
 
         new_password = "NewPassword456!"
+        csrf_response = await async_client.get("/api/v1/csrf-token")
+        csrf_token = csrf_response.json()["csrf_token"]
         reset_response = await async_client.post(
             "/api/v1/auth/reset-password",
             json={
                 "token": reset_token,
                 "new_password": new_password
-            }
+            },
+            headers={"X-CSRF-Token": csrf_token},
         )
         assert reset_response.status_code == 200, "パスワードリセットが成功"
 
@@ -816,12 +819,15 @@ class TestSessionInvalidation:
         assert len(blacklist_entries) > 0, "ブラックリストエントリが作成されていること"
 
         # パスワード変更後に新しくログインして新しいリフレッシュトークンを取得
+        csrf_response = await async_client.get("/api/v1/csrf-token")
+        csrf_token = csrf_response.json()["csrf_token"]
         new_login_response = await async_client.post(
             "/api/v1/auth/token",
             data={
                 "username": staff_email,
                 "password": new_password
-            }
+            },
+            headers={"X-CSRF-Token": csrf_token},
         )
         assert new_login_response.status_code == 200, "新しいパスワードでログイン成功"
         new_refresh_token = new_login_response.json()["refresh_token"]
@@ -831,7 +837,8 @@ class TestSessionInvalidation:
         # 新しいリフレッシュトークンは有効であるべき
         new_refresh_response = await async_client.post(
             "/api/v1/auth/refresh-token",
-            json={"refresh_token": new_refresh_token}
+            json={"refresh_token": new_refresh_token},
+            headers={"X-CSRF-Token": csrf_token},
         )
         assert new_refresh_response.status_code == 200, (
             "パスワード変更後に発行された新しいリフレッシュトークンは有効であるべき"

--- a/tests/performance/snapshots/test_list_1.json
+++ b/tests/performance/snapshots/test_list_1.json
@@ -1,0 +1,96 @@
+{
+  "schema_version": "1.0.0",
+  "name": "test_list_1",
+  "created_at": "2026-04-16T14:50:54.595421",
+  "description": "Test snapshot 1",
+  "stats": {
+    "offices": 2,
+    "staffs": 1,
+    "office_staffs": 0,
+    "welfare_recipients": 0,
+    "office_welfare_recipients": 0,
+    "support_plan_cycles": 0
+  },
+  "tables": {
+    "offices": [
+      {
+        "id": "6283c3f2-10fa-4d33-9dea-2ac1be0987a1",
+        "name": "テスト事業所0000",
+        "is_group": false,
+        "type": "type_B_office",
+        "created_by": "db1a2506-2a66-40ab-ac3f-05ef54693f4f",
+        "last_modified_by": "db1a2506-2a66-40ab-ac3f-05ef54693f4f",
+        "deactivated_at": null,
+        "created_at": "2026-04-16T14:50:52.406522+00:00",
+        "updated_at": "2026-04-16T14:50:52.406522+00:00",
+        "is_test_data": true,
+        "address": "東京都テスト区テスト町0-1-1",
+        "phone_number": "03-0000-0000",
+        "email": "office0000@test-example.com",
+        "is_deleted": false,
+        "deleted_at": null,
+        "deleted_by": null
+      },
+      {
+        "id": "4132abdd-bb50-426f-a194-1b710560919d",
+        "name": "テスト事業所0001",
+        "is_group": false,
+        "type": "type_B_office",
+        "created_by": "db1a2506-2a66-40ab-ac3f-05ef54693f4f",
+        "last_modified_by": "db1a2506-2a66-40ab-ac3f-05ef54693f4f",
+        "deactivated_at": null,
+        "created_at": "2026-04-16T14:50:52.406522+00:00",
+        "updated_at": "2026-04-16T14:50:52.406522+00:00",
+        "is_test_data": true,
+        "address": "東京都テスト区テスト町1-1-1",
+        "phone_number": "03-0000-0001",
+        "email": "office0001@test-example.com",
+        "is_deleted": false,
+        "deleted_at": null,
+        "deleted_by": null
+      }
+    ],
+    "staffs": [
+      {
+        "id": "db1a2506-2a66-40ab-ac3f-05ef54693f4f",
+        "email": "system_admin@test-example.com",
+        "hashed_password": "$2b$12$a0MwlYhJbiNlWM4lfRqsPucSWeo.w92vGj3k6uiDmfnqunUvQ55hW",
+        "name": null,
+        "role": "owner",
+        "created_at": "2026-04-16T14:50:52.406522+00:00",
+        "updated_at": "2026-04-16T14:50:52.406522+00:00",
+        "is_email_verified": true,
+        "is_mfa_enabled": false,
+        "mfa_secret": null,
+        "mfa_backup_codes_used": 0,
+        "last_name": "管理者",
+        "first_name": "システム",
+        "last_name_furigana": null,
+        "first_name_furigana": null,
+        "full_name": "管理者 システム",
+        "password_changed_at": null,
+        "failed_password_attempts": 0,
+        "is_locked": false,
+        "locked_at": null,
+        "is_mfa_verified_by_user": false,
+        "is_test_data": true,
+        "is_deleted": false,
+        "deleted_at": null,
+        "deleted_by": null,
+        "hashed_passphrase": null,
+        "passphrase_changed_at": null,
+        "notification_preferences": {
+          "email_notification": true,
+          "in_app_notification": true,
+          "push_threshold_days": 10,
+          "system_notification": false,
+          "email_threshold_days": 30
+        }
+      }
+    ],
+    "office_staffs": [],
+    "welfare_recipients": [],
+    "office_welfare_recipients": [],
+    "support_plan_cycles": []
+  }
+}

--- a/tests/scripts/test_alembic_baseline_guard.py
+++ b/tests/scripts/test_alembic_baseline_guard.py
@@ -1,0 +1,76 @@
+from types import SimpleNamespace
+
+import pytest
+
+from scripts.alembic_baseline_guard import (
+    BASELINE_REVISION,
+    normalize_database_url,
+    revision_includes_baseline,
+    validate_current_heads,
+)
+
+
+class FakeScript:
+    def __init__(self, chains):
+        self.chains = chains
+
+    def iterate_revisions(self, current_revision, baseline_revision):
+        chain = self.chains.get((current_revision, baseline_revision))
+        if chain is None:
+            raise ValueError("unknown revision chain")
+        return [SimpleNamespace(revision=revision) for revision in chain]
+
+
+class LazyFailScript:
+    def iterate_revisions(self, current_revision, baseline_revision):
+        def fail_on_iteration():
+            raise ValueError("not an ancestor")
+            yield
+
+        return fail_on_iteration()
+
+
+def test_normalize_database_url_converts_asyncpg_url():
+    url = "postgresql+asyncpg://user:pass@example.com/db"
+
+    assert normalize_database_url(url) == "postgresql://user:pass@example.com/db"
+
+
+def test_revision_includes_baseline_accepts_exact_baseline():
+    script = FakeScript({})
+
+    assert revision_includes_baseline(script, BASELINE_REVISION)
+
+
+def test_validate_current_heads_accepts_revision_after_baseline():
+    script = FakeScript(
+        {
+            ("future_revision", BASELINE_REVISION): [
+                "future_revision",
+                BASELINE_REVISION,
+            ]
+        }
+    )
+
+    assert validate_current_heads(["future_revision"], script) == ("future_revision",)
+
+
+def test_validate_current_heads_rejects_revision_before_baseline():
+    script = FakeScript({})
+
+    with pytest.raises(RuntimeError, match="not at or after baseline_20260701"):
+        validate_current_heads(["n3o4p5q6r7s8"], script)
+
+
+def test_validate_current_heads_rejects_lazy_revision_lookup_error():
+    script = LazyFailScript()
+
+    with pytest.raises(RuntimeError, match="not at or after baseline_20260701"):
+        validate_current_heads(["m2n3o4p5q6r7"], script)
+
+
+def test_validate_current_heads_rejects_empty_current():
+    script = FakeScript({})
+
+    with pytest.raises(RuntimeError, match="current revision is empty"):
+        validate_current_heads([], script)

--- a/tests/services/test_calendar_deprecation_boundary_services.py
+++ b/tests/services/test_calendar_deprecation_boundary_services.py
@@ -1,0 +1,217 @@
+from types import SimpleNamespace
+from uuid import uuid4
+
+import pytest
+
+from app.models.enums import CalendarEventType, CalendarSyncStatus, SupportPlanStep
+from app.services.calendar.calendar_sync_result_service import CalendarSyncResultService
+from app.services.calendar.google_calendar_account_service import GoogleCalendarAccountService
+from app.services.calendar.google_calendar_sync_service import GoogleCalendarSyncService
+from app.services.calendar.support_plan_calendar_event_service import (
+    SupportPlanCalendarEventService,
+)
+
+
+class FakeAccountService:
+    def __init__(self):
+        self.calls = []
+
+    async def get_connected_service_account_json(self, db, office_id):
+        self.calls.append((db, office_id))
+        return "service-account-json"
+
+
+class FakeSyncResultService:
+    def __init__(self):
+        self.calls = []
+
+    async def mark_synced(self, db, event, google_event_id):
+        self.calls.append(("synced", db, event, google_event_id))
+
+    async def mark_failed(self, db, event, message):
+        self.calls.append(("failed", db, event, message))
+
+
+class FakeGateway:
+    def __init__(self):
+        self.calls = []
+
+    def create_event(
+        self,
+        *,
+        service_account_json,
+        calendar_id,
+        title,
+        description,
+        start_datetime,
+        end_datetime,
+    ):
+        self.calls.append(
+            (
+                service_account_json,
+                calendar_id,
+                title,
+                description,
+                start_datetime,
+                end_datetime,
+            )
+        )
+        return "google-event-id"
+
+    def delete_event(self, *, service_account_json, calendar_id, event_id):
+        self.calls.append(("delete", service_account_json, calendar_id, event_id))
+
+
+@pytest.mark.asyncio
+async def test_google_sync_service_separates_account_resolution_and_result_updates():
+    account_service = FakeAccountService()
+    result_service = FakeSyncResultService()
+    gateway = FakeGateway()
+    service = GoogleCalendarSyncService(
+        gateway=gateway,
+        account_service=account_service,
+        sync_result_service=result_service,
+    )
+    db = object()
+    office_id = uuid4()
+    event = SimpleNamespace(
+        office_id=office_id,
+        google_calendar_id="calendar-id",
+        event_title="title",
+        event_description="description",
+        event_start_datetime="start",
+        event_end_datetime="end",
+    )
+
+    result = await service.sync_event_group(db=db, office_id=office_id, events=[event])
+
+    assert result == {"synced": 1, "failed": 0}
+    assert account_service.calls == [(db, office_id)]
+    assert gateway.calls == [
+        ("service-account-json", "calendar-id", "title", "description", "start", "end")
+    ]
+    assert result_service.calls == [("synced", db, event, "google-event-id")]
+
+
+def test_google_sync_service_exposes_boundary_services():
+    service = GoogleCalendarSyncService()
+
+    assert isinstance(service.account_service, GoogleCalendarAccountService)
+    assert isinstance(service.sync_result_service, CalendarSyncResultService)
+
+
+class FakeRecipientLedgerService:
+    def __init__(self, events):
+        self.events = events
+        self.calls = []
+
+    async def get_events_by_recipient(self, db, recipient_id):
+        self.calls.append((db, recipient_id))
+        return self.events
+
+
+@pytest.mark.asyncio
+async def test_google_sync_service_deletes_recipient_events_without_db_delete():
+    office_id = uuid4()
+    recipient_id = uuid4()
+    event = SimpleNamespace(
+        office_id=office_id,
+        google_calendar_id="calendar-id",
+        google_event_id="google-event-id",
+    )
+    ledger_service = FakeRecipientLedgerService(events=[event])
+    account_service = FakeAccountService()
+    gateway = FakeGateway()
+    service = GoogleCalendarSyncService(
+        gateway=gateway,
+        event_ledger_service=ledger_service,
+        account_service=account_service,
+    )
+    db = object()
+
+    deleted_count = await service.delete_google_events_for_recipient(
+        db=db,
+        recipient_id=recipient_id,
+    )
+
+    assert deleted_count == 1
+    assert ledger_service.calls == [(db, recipient_id)]
+    assert account_service.calls == [(db, office_id)]
+    assert gateway.calls == [("delete", "service-account-json", "calendar-id", "google-event-id")]
+
+
+class FakeCalendarService:
+    def __init__(self):
+        self.calls = []
+
+    async def create_renewal_deadline_events(self, **kwargs):
+        self.calls.append(("create_renewal_deadline_events", kwargs))
+        return ["renewal"]
+
+    async def create_next_plan_start_date_events(self, **kwargs):
+        self.calls.append(("create_next_plan_start_date_events", kwargs))
+        return ["monitoring"]
+
+    async def delete_event_by_cycle(self, **kwargs):
+        self.calls.append(("delete_event_by_cycle", kwargs))
+        return True
+
+    async def delete_event_by_status(self, **kwargs):
+        self.calls.append(("delete_event_by_status", kwargs))
+        return True
+
+
+@pytest.mark.asyncio
+async def test_support_plan_calendar_event_service_hides_calendar_facade_calls():
+    calendar_service = FakeCalendarService()
+    service = SupportPlanCalendarEventService(calendar_service=calendar_service)
+    db = object()
+    cycle = SimpleNamespace(
+        id=10,
+        office_id=uuid4(),
+        welfare_recipient_id=uuid4(),
+        next_renewal_deadline="deadline",
+        plan_cycle_start_date="start-date",
+        cycle_number=2,
+    )
+    monitoring_status = SimpleNamespace(id=20)
+
+    created = await service.create_cycle_events(
+        db=db,
+        cycle=cycle,
+        monitoring_status=monitoring_status,
+    )
+    renewal_deleted = await service.delete_completion_event(
+        db=db,
+        step_type=SupportPlanStep.final_plan_signed,
+        cycle_id=cycle.id,
+        status_id=monitoring_status.id,
+    )
+    monitoring_deleted = await service.delete_completion_event(
+        db=db,
+        step_type=SupportPlanStep.monitoring,
+        cycle_id=cycle.id,
+        status_id=monitoring_status.id,
+    )
+
+    assert created == {"renewal_event_ids": ["renewal"], "monitoring_event_ids": ["monitoring"]}
+    assert renewal_deleted is True
+    assert monitoring_deleted is True
+    assert calendar_service.calls[0][0] == "create_renewal_deadline_events"
+    assert calendar_service.calls[1][0] == "create_next_plan_start_date_events"
+    assert calendar_service.calls[2] == (
+        "delete_event_by_cycle",
+        {
+            "db": db,
+            "cycle_id": cycle.id,
+            "event_type": CalendarEventType.renewal_deadline,
+        },
+    )
+    assert calendar_service.calls[3] == (
+        "delete_event_by_status",
+        {
+            "db": db,
+            "status_id": monitoring_status.id,
+            "event_type": CalendarEventType.next_plan_start_date,
+        },
+    )


### PR DESCRIPTION
## Summary
- add owner dependency that eagerly loads office associations for billing endpoints
- exempt auth login/MFA endpoints from stale-cookie CSRF blocking while keeping protected state changes guarded
- add Alembic baseline guard, production migration step, and related tests/scripts

## Validation
- docker compose exec -T backend python3 -m compileall app/api/deps.py app/api/v1/endpoints/billing.py app/api/v1/endpoints/support_plan_statuses.py app/api/v1/endpoints/welfare_recipients.py app/main.py scripts/alembic_baseline_guard.py
- docker compose exec -T backend pytest tests/api/test_billing.py tests/api/test_deps_permissions.py tests/api/v1/test_csrf_protection.py tests/scripts/test_alembic_baseline_guard.py