### PR TITLE
[codex] Mask staff profile audit values

### DIFF
--- a/app/services/staff_profile_service.py
+++ b/app/services/staff_profile_service.py
@@ -15,6 +15,7 @@ from app.schemas.staff_profile import StaffNameUpdate, PasswordChange, EmailChan
 from app.core.security import verify_password, get_password_hash
 from app.core import mail
 from app.messages import ja
+from app.utils.privacy_utils import mask_email, mask_name
 
 pwd_context = CryptContext(schemes=["bcrypt"], deprecated="auto")
 logger = logging.getLogger(__name__)
@@ -92,8 +93,8 @@ class StaffProfileService:
         audit_log = AuditLog(
             staff_id=staff_id,
             action="UPDATE_NAME",
-            old_value=old_name,
-            new_value=new_name,
+            old_value=mask_name(old_name),
+            new_value=mask_name(new_name),
             timestamp=datetime.now(timezone.utc)
         )
         db.add(audit_log)
@@ -606,8 +607,8 @@ class StaffProfileService:
         audit_log = AuditLog(
             staff_id=staff.id,
             action="UPDATE_EMAIL",
-            old_value=old_email,
-            new_value=new_email,
+            old_value=mask_email(old_email),
+            new_value=mask_email(new_email),
             timestamp=datetime.now(timezone.utc)
         )
         db.add(audit_log)

--- a/app/utils/privacy_utils.py
+++ b/app/utils/privacy_utils.py
@@ -43,6 +43,10 @@ REDACT_DETAIL_KEYS = {
     "api_key",
     "authorization",
     "cookie",
+    "raw_payload",
+    "raw_details",
+    "request_body",
+    "response_body",
 }
 AUDIT_LOG_ACTION_ALLOWED_DETAIL_KEYS = {
     "billing.status_changed": {

--- a/tests/services/test_staff_profile_service.py
+++ b/tests/services/test_staff_profile_service.py
@@ -119,8 +119,8 @@ class TestStaffProfileServiceNameUpdate:
         audit_log = mock_db.add.call_args[0][0]
         assert isinstance(audit_log, AuditLog)
         assert audit_log.action == "UPDATE_NAME"
-        assert audit_log.old_value == "旧姓 旧名"
-        assert audit_log.new_value == "山田 太郎"
+        assert audit_log.old_value == "旧姓 *"
+        assert audit_log.new_value == "山田 *"
 
 
 class TestStaffProfileServicePasswordChange:

--- a/tests/services/test_staff_profile_service_email.py
+++ b/tests/services/test_staff_profile_service_email.py
@@ -265,8 +265,8 @@ class TestEmailChangeVerification:
         audit_log = mock_db.add.call_args[0][0]
         assert isinstance(audit_log, AuditLog)
         assert audit_log.action == "UPDATE_EMAIL"
-        assert audit_log.old_value == "old.email@example.com"
-        assert audit_log.new_value == "new.email@example.com"
+        assert audit_log.old_value == "o***@example.com"
+        assert audit_log.new_value == "n***@example.com"
 
         # 完了通知メールが送信されたことを確認
         mock_completed.assert_called_once()

--- a/tests/utils/test_privacy_utils.py
+++ b/tests/utils/test_privacy_utils.py
@@ -188,6 +188,7 @@ def test_mask_sensitive_details_for_display_recursively_masks_known_sensitive_ke
         "full_name": "山田 太郎",
         "stripe_customer_id": "cus_1234567890abcdef",
         "access_token": "raw-access-token-value",
+        "raw_payload": {"customer_email": "customer@example.com"},
         "changes": {
             "address": "東京都新宿区1-2-3",
             "phone_number": "090-1234-5678",
@@ -201,6 +202,7 @@ def test_mask_sensitive_details_for_display_recursively_masks_known_sensitive_ke
         "full_name": "山田 *",
         "stripe_customer_id": "<present>",
         "access_token": "<redacted>",
+        "raw_payload": "<redacted>",
         "changes": {
             "address": "<redacted>",
             "phone_number": "<redacted>",


### PR DESCRIPTION
## Summary

- スタッフプロフィールの名前やメールアドレスを保存する前に、旧値と新値の監査を行う
- プライバシーユーティリティにおいて、ペイロード、詳細、リクエスト、レスポンスのボディ内のキーを、情報が伏せられたものとして扱う
- マスクされた保存動作に合わせて、スタッフプロフィールおよびプライバシーユーティリティのテストを更新する

## Scope

このPRは意図的に `feature/masking-tdd-01` をベースにしているため、diffにはスタッフプロファイルの監査値のマスキングに関する増分変更のみが含まれています。

## Validation

- `docker exec keikakun_app-backend-1 pytest tests/services/test_staff_profile_service.py tests/services/test_staff_profile_service_email.py tests/utils/test_privacy_utils.py -q`
- Result: `35 passed`

## Notes

- Markdown documentation changes are intentionally excluded.
- `.coverage` and unrelated parent repository doc changes are not included.