### PR TITLE
Mask bulk MFA setup response

### DIFF
--- a/app/api/v1/endpoints/mfa.py
+++ b/app/api/v1/endpoints/mfa.py
@@ -384,7 +384,7 @@ async def enable_all_office_mfa(
     Returns:
         - message: 成功メッセージ
         - enabled_count: 有効化されたスタッフ数
-        - staff_mfa_data: 各スタッフのMFA設定情報（QRコード、シークレットキー、リカバリーコード）
+        - enabled_staffs: 有効化されたスタッフの最小情報
     """
     from sqlalchemy import select
     from sqlalchemy.orm import selectinload
@@ -423,8 +423,8 @@ async def enable_all_office_mfa(
     result_staffs = await db.execute(stmt_staffs)
     all_staffs = result_staffs.scalars().all()
 
-    # MFAが無効なスタッフのみ有効化し、設定情報を収集
-    staff_mfa_data = []
+    # MFAが無効なスタッフのみ有効化し、レスポンスは最小情報に限定する
+    enabled_staffs = []
     enabled_count = 0
 
     try:
@@ -432,7 +432,6 @@ async def enable_all_office_mfa(
             if not staff.is_mfa_enabled:
                 # MFAシークレットとリカバリーコードを生成
                 secret = generate_totp_secret()
-                totp_uri = generate_totp_uri(staff.email, secret)
                 recovery_codes = generate_recovery_codes()
 
                 # MFAを有効化（暗号化して保存）
@@ -442,13 +441,10 @@ async def enable_all_office_mfa(
                 staff.is_mfa_verified_by_user = False
                 enabled_count += 1
 
-                # スタッフごとのMFA設定情報を収集
-                staff_mfa_data.append({
+                enabled_staffs.append({
                     "staff_id": str(staff.id),
                     "staff_name": staff.full_name,
-                    "qr_code_uri": totp_uri,
-                    "secret_key": secret,
-                    "recovery_codes": recovery_codes
+                    "setup_required": True,
                 })
 
         await db.commit()
@@ -466,7 +462,6 @@ async def enable_all_office_mfa(
     return {
         "message": f"{enabled_count}名のスタッフのMFAを有効化しました。",
         "enabled_count": enabled_count,
-        "staff_mfa_data": staff_mfa_data
+        "enabled_staffs": enabled_staffs
     }
-
 

--- a/tests/api/v1/test_mfa_admin.py
+++ b/tests/api/v1/test_mfa_admin.py
@@ -498,7 +498,7 @@ class TestAdminMFABulkOperations:
         期待される結果:
         - ステータスコード: 200
         - 全スタッフのis_mfa_enabledがTrueになる
-        - 各スタッフのQRコード、シークレットキー、リカバリーコードが返される
+        - secret / QR code URI / recovery codes は一括レスポンスに返されない
         """
         # Arrange
         owner = office_with_multiple_staffs["owner"]
@@ -527,20 +527,24 @@ class TestAdminMFABulkOperations:
         data = response.json()
         assert "message" in data
         assert "enabled_count" in data
-        assert "staff_mfa_data" in data
+        assert "enabled_staffs" in data
+        assert "staff_mfa_data" not in data
         assert data["enabled_count"] == 4  # 全員有効化
 
-        # スタッフごとのMFA設定情報が含まれているか確認
-        staff_mfa_data = data["staff_mfa_data"]
-        assert len(staff_mfa_data) == 4
+        serialized = str(data)
+        assert "otpauth://" not in serialized
+        assert "secret_key" not in serialized
+        assert "qr_code_uri" not in serialized
+        assert "recovery_codes" not in serialized
 
-        for staff_data in staff_mfa_data:
+        # スタッフごとの最小情報だけが含まれることを確認
+        enabled_staffs = data["enabled_staffs"]
+        assert len(enabled_staffs) == 4
+
+        for staff_data in enabled_staffs:
             assert "staff_id" in staff_data
             assert "staff_name" in staff_data
-            assert "qr_code_uri" in staff_data
-            assert "secret_key" in staff_data
-            assert "recovery_codes" in staff_data
-            assert len(staff_data["recovery_codes"]) == 10
+            assert staff_data["setup_required"] is True
 
         # Assert: DB検証
         await db_session.refresh(owner)


### PR DESCRIPTION
## Summary
- オフィスの一括有効化エンドポイントから、MFA QR URI、生のシークレット、およびリカバリーコードを返さないようにする
- 有効化されたスタッフのID/名前と「setup_required」のみを返す
- 管理者のMFA一括応答テストを更新し、シークレットがシリアライズされていないことを確認するようにする

## Validation
- git diff --cached --check before commit