### PR TITLE
Avoid presigned URLs in deliverable lists

### DIFF
--- a/app/services/support_plan_service.py
+++ b/app/services/support_plan_service.py
@@ -524,8 +524,6 @@ class SupportPlanService:
             StaffBrief,
             PlanCycleBrief,
         )
-        from app.core import storage
-        from app.core.config import settings
 
         # フィルター条件の構築
         filters = {}
@@ -570,18 +568,6 @@ class SupportPlanService:
         # レスポンスデータの構築
         items = []
         for deliverable in deliverables:
-            # S3パスから署名付きURL生成
-            object_name = deliverable.file_path.replace(f"s3://{settings.S3_BUCKET_NAME}/", "")
-            try:
-                download_url = await storage.create_presigned_url(
-                    object_name=object_name,
-                    expiration=3600,  # 1時間
-                    inline=True
-                )
-            except Exception as e:
-                logger.warning("Failed to generate presigned URL: %s", type(e).__name__)
-                download_url = None
-
             # レスポンスオブジェクト作成
             item = PlanDeliverableListItem(
                 id=deliverable.id,
@@ -610,7 +596,7 @@ class SupportPlanService:
                     role=deliverable.uploaded_by_staff.role.value,
                 ),
                 uploaded_at=deliverable.uploaded_at,
-                download_url=download_url,
+                download_url=None,
             )
             items.append(item)
 

--- a/tests/services/test_support_plan_service_deliverables_list.py
+++ b/tests/services/test_support_plan_service_deliverables_list.py
@@ -152,11 +152,12 @@ class TestGetDeliverablesList:
                     assert item1.welfare_recipient.full_name == "山田 太郎"
                     assert item1.plan_cycle.cycle_number == 1
                     assert item1.uploaded_by.name == "アップロード者"
-                    assert item1.download_url == "https://s3.amazonaws.com/test-bucket/signed-url"
+                    assert item1.download_url is None
 
                     # CRUD層が正しく呼ばれたか確認
                     mock_get_multi.assert_called_once()
                     mock_count.assert_called_once()
+                    mock_presigned.assert_not_called()
 
     async def test_get_deliverables_list_with_filters(
         self,
@@ -276,11 +277,11 @@ class TestGetDeliverablesList:
         sample_deliverables_data
     ):
         """
-        異常系: S3 presigned URL生成エラー時のハンドリング
+        正常系: PDF一覧では署名付きURLを生成しない
 
-        Given: S3 URL生成でエラーが発生
+        Given: PDFデータが存在
         When: get_deliverables_listを呼び出す
-        Then: download_urlがNoneになり、処理は続行される
+        Then: download_urlはNoneで、署名付きURL生成は呼ばれない
         """
         deliverables, office_id = sample_deliverables_data
 
@@ -289,7 +290,6 @@ class TestGetDeliverablesList:
                 with patch('app.core.storage.create_presigned_url') as mock_presigned:
                     mock_get_multi.return_value = deliverables
                     mock_count.return_value = 2
-                    # S3エラーをシミュレート
                     mock_presigned.side_effect = Exception("S3 connection error")
 
                     # テスト実行
@@ -308,6 +308,7 @@ class TestGetDeliverablesList:
                     # download_urlがNoneになっている
                     assert result.items[0].download_url is None
                     assert result.items[1].download_url is None
+                    mock_presigned.assert_not_called()
 
     async def test_deliverable_type_display_mapping(
         self,


### PR DESCRIPTION
## Summary
- サポートプランの成果物リストへの返信において、事前署名済みダウンロードURLの生成を停止する
- リスト項目では download_url を null に保ち、ファイルへのアクセスが明示的な詳細表示／ダウンロードフローの範囲内にとどまるようにする
- サービステストを更新し、事前署名済みURLの生成が呼び出されないことを確認する

## Validation
- git diff --cached --check before commit