### PR TITLE
[codex] Fix alembic baseline guard ancestry check

### DIFF
--- a/scripts/alembic_baseline_guard.py
+++ b/scripts/alembic_baseline_guard.py
@@ -30,9 +30,29 @@ def revision_includes_baseline(
 
     try:
         revisions = script.iterate_revisions(current_revision, baseline_revision)
-        return any(revision.revision == baseline_revision for revision in revisions)
+        return any(
+            revision.revision == baseline_revision
+            or down_revision_includes(
+                getattr(revision, "down_revision", None),
+                baseline_revision,
+            )
+            for revision in revisions
+        )
     except Exception:
         return False
+
+
+def down_revision_includes(down_revision: object, baseline_revision: str) -> bool:
+    if down_revision is None:
+        return False
+
+    if isinstance(down_revision, str):
+        return down_revision == baseline_revision
+
+    if isinstance(down_revision, (tuple, list, set)):
+        return baseline_revision in down_revision
+
+    return False
 
 
 def validate_current_heads(

--- a/tests/scripts/test_alembic_baseline_guard.py
+++ b/tests/scripts/test_alembic_baseline_guard.py
@@ -11,14 +11,21 @@ from scripts.alembic_baseline_guard import (
 
 
 class FakeScript:
-    def __init__(self, chains):
+    def __init__(self, chains, down_revisions=None):
         self.chains = chains
+        self.down_revisions = down_revisions or {}
 
     def iterate_revisions(self, current_revision, baseline_revision):
         chain = self.chains.get((current_revision, baseline_revision))
         if chain is None:
             raise ValueError("unknown revision chain")
-        return [SimpleNamespace(revision=revision) for revision in chain]
+        return [
+            SimpleNamespace(
+                revision=revision,
+                down_revision=self.down_revisions.get(revision),
+            )
+            for revision in chain
+        ]
 
 
 class LazyFailScript:
@@ -53,6 +60,32 @@ def test_validate_current_heads_accepts_revision_after_baseline():
     )
 
     assert validate_current_heads(["future_revision"], script) == ("future_revision",)
+
+
+def test_validate_current_heads_accepts_direct_child_when_iterate_omits_baseline():
+    script = FakeScript(
+        {
+            ("mrg20260703p9q0", BASELINE_REVISION): [
+                "mrg20260703p9q0",
+            ]
+        },
+        down_revisions={"mrg20260703p9q0": BASELINE_REVISION},
+    )
+
+    assert validate_current_heads(["mrg20260703p9q0"], script) == ("mrg20260703p9q0",)
+
+
+def test_validate_current_heads_accepts_merge_child_when_iterate_omits_baseline():
+    script = FakeScript(
+        {
+            ("merge_revision", BASELINE_REVISION): [
+                "merge_revision",
+            ]
+        },
+        down_revisions={"merge_revision": ("other_head", BASELINE_REVISION)},
+    )
+
+    assert validate_current_heads(["merge_revision"], script) == ("merge_revision",)
 
 
 def test_validate_current_heads_rejects_revision_before_baseline():


### PR DESCRIPTION
## Summary
- fix the Alembic baseline guard to accept revisions whose down_revision points to the configured baseline
- add regression coverage for Alembic iterate_revisions omitting the lower endpoint
- cover merge revisions where down_revision is a tuple containing the baseline

## Root cause
Cloud Build failed at the baseline guard even though production was at mrg20260703p9q0, which is a child of baseline_20260701. Alembic iterate_revisions(current, baseline) can omit the lower endpoint, so the guard incorrectly treated the child revision as being before the baseline.

## Validation
- docker compose exec -T backend pytest tests/scripts/test_alembic_baseline_guard.py
- docker compose exec -T backend python - <<'PY'
from alembic.config import Config
from alembic.script import ScriptDirectory
from scripts.alembic_baseline_guard import revision_includes_baseline
script = ScriptDirectory.from_config(Config('alembic.ini'))
print('mrg20260703p9q0 includes baseline:', revision_includes_baseline(script, 'mrg20260703p9q0', 'baseline_20260701'))
PY