### PR TITLE
[codex] fix CSRF dependency cleanup for issue 167

### DIFF
--- a/app/api/deps.py
+++ b/app/api/deps.py
@@ -208,7 +208,6 @@ async def require_manager_or_owner(
         )
     return current_staff
 
-
 async def require_owner(
     current_staff: Staff = Depends(get_current_user_minimal)
 ) -> Staff:
@@ -384,42 +383,3 @@ async def require_active_billing(
         )
 
     return current_staff
-
-
-# --- CSRF保護依存関数 ---
-
-async def validate_csrf(
-    request: Request,
-) -> None:
-    """
-    CSRFトークンを検証する依存関数
-
-    Cookie認証を使用している場合のみCSRF検証を行う。
-    Bearer認証（Authorizationヘッダー）の場合は検証をスキップ。
-
-    Args:
-        request: FastAPIリクエストオブジェクト
-
-    Raises:
-        HTTPException: CSRFトークンが無効な場合
-    """
-    from fastapi_csrf_protect import CsrfProtect
-    from fastapi_csrf_protect.exceptions import CsrfProtectError
-
-    # Authorizationヘッダーがある場合（Bearer認証）はCSRF検証をスキップ
-    auth_header = request.headers.get("Authorization")
-    if auth_header and auth_header.startswith("Bearer "):
-        return
-
-    # Cookie認証を使用している場合、CSRF検証を行う
-    access_token_cookie = request.cookies.get("access_token")
-    if access_token_cookie:
-        csrf_protect = CsrfProtect()
-        try:
-            await csrf_protect.validate_csrf(request)
-        except CsrfProtectError as e:
-            logger.warning("CSRF validation failed: %s", type(e).__name__)
-            raise HTTPException(
-                status_code=status.HTTP_403_FORBIDDEN,
-                detail=f"CSRF token validation failed"
-            )

--- a/app/api/v1/endpoints/admin_announcements.py
+++ b/app/api/v1/endpoints/admin_announcements.py
@@ -3,12 +3,12 @@ app_admin用お知らせAPIエンドポイント
 
 全スタッフへのお知らせ（MessageType.announcement）を管理
 """
-from fastapi import APIRouter, Depends, Query, Request, HTTPException, status
+from fastapi import APIRouter, Depends, Query, HTTPException, status
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy import select, func
 from sqlalchemy.orm import selectinload
 
-from app.api.deps import get_db, require_app_admin, validate_csrf
+from app.api.deps import get_db, require_app_admin
 from app.models.staff import Staff
 from app.models.message import Message
 from app.models.enums import MessageType
@@ -79,11 +79,9 @@ async def get_announcements(
 @router.post("", response_model=MessageDetailResponse, status_code=status.HTTP_201_CREATED)
 async def send_announcement_to_all(
     *,
-    request: Request,
     db: AsyncSession = Depends(get_db),
     current_user: Staff = Depends(require_app_admin),
     message_in: MessageAnnouncementCreate,
-    _: None = Depends(validate_csrf)
 ):
     """
     全事務所の全スタッフへお知らせを送信（app_admin専用）
@@ -99,6 +97,7 @@ async def send_announcement_to_all(
             Staff.is_deleted == False,  # noqa: E712
             Staff.id != current_user.id
         )
+        .options(selectinload(Staff.office_associations))
     )
     all_staff_result = await db.execute(all_staff_query)
     all_staff = list(all_staff_result.scalars().all())
@@ -109,10 +108,20 @@ async def send_announcement_to_all(
             detail="送信先のスタッフが存在しません"
         )
 
-    # 事務所IDを取得（最初のスタッフの事務所、またはNone）
-    office_id = None
-    if all_staff and all_staff[0].office_associations:
-        office_id = all_staff[0].office_associations[0].office_id
+    # messages.office_id は必須のため、送信対象の中から所属事務所を持つスタッフを探す
+    office_id = next(
+        (
+            staff.office_associations[0].office_id
+            for staff in all_staff
+            if staff.office_associations
+        ),
+        None,
+    )
+    if office_id is None:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="送信先の事務所が見つかりません"
+        )
 
     recipient_ids = [staff.id for staff in all_staff]
 

--- a/app/api/v1/endpoints/messages.py
+++ b/app/api/v1/endpoints/messages.py
@@ -3,7 +3,7 @@
 
 個別メッセージ、一斉通知、受信箱、統計などのAPI
 """
-from fastapi import APIRouter, Depends, HTTPException, status, Query, Request
+from fastapi import APIRouter, Depends, HTTPException, status, Query
 from sqlalchemy.ext.asyncio import AsyncSession
 from typing import Optional, List
 from uuid import UUID
@@ -35,11 +35,9 @@ router = APIRouter()
 @router.post("/personal", response_model=MessageDetailResponse, status_code=status.HTTP_201_CREATED)
 async def send_personal_message(
     *,
-    request: Request,
     db: AsyncSession = Depends(deps.get_db),
     current_user: Staff = Depends(deps.get_current_user),
     message_in: MessagePersonalCreate,
-    _: None = Depends(deps.validate_csrf)
 ):
     """
     個別メッセージを送信
@@ -110,11 +108,9 @@ async def send_personal_message(
 @router.post("/announcement", response_model=MessageDetailResponse, status_code=status.HTTP_201_CREATED)
 async def send_announcement(
     *,
-    request: Request,
     db: AsyncSession = Depends(deps.get_db),
     current_user: Staff = Depends(deps.get_current_user),
     message_in: MessageAnnouncementCreate,
-    _: None = Depends(deps.validate_csrf)
 ):
     """
     一斉通知を送信（事務所内の全スタッフへ）
@@ -253,11 +249,9 @@ async def get_inbox_messages(
 @router.post("/{message_id}/read", response_model=MessageRecipientResponse)
 async def mark_message_as_read(
     *,
-    request: Request,
     db: AsyncSession = Depends(deps.get_db),
     current_user: Staff = Depends(deps.get_current_user),
     message_id: UUID,
-    _: None = Depends(deps.validate_csrf)
 ):
     """
     メッセージを既読にする
@@ -342,10 +336,8 @@ async def get_unread_count(
 @router.post("/mark-all-read")
 async def mark_all_as_read(
     *,
-    request: Request,
     db: AsyncSession = Depends(deps.get_db),
     current_user: Staff = Depends(deps.get_current_user),
-    _: None = Depends(deps.validate_csrf)
 ):
     """
     全未読メッセージを既読にする

--- a/app/api/v1/endpoints/offices.py
+++ b/app/api/v1/endpoints/offices.py
@@ -1,6 +1,6 @@
 from typing import Any
 
-from fastapi import APIRouter, Depends, HTTPException, status, Request
+from fastapi import APIRouter, Depends, HTTPException, status
 from sqlalchemy import select
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -212,11 +212,9 @@ async def get_all_office_staffs(
 @router.put("/me", response_model=schemas.OfficeResponse)
 async def update_office_info(
     *,
-    request: Request,
     db: AsyncSession = Depends(deps.get_db),
     office_in: schemas.OfficeInfoUpdate,
     current_user: models.Staff = Depends(deps.require_owner),
-    _: None = Depends(deps.validate_csrf),
 ) -> Any:
     """
     事務所情報を更新（オーナーのみ）

--- a/tests/api/v1/test_csrf_protection.py
+++ b/tests/api/v1/test_csrf_protection.py
@@ -9,7 +9,39 @@ from httpx import AsyncClient
 from sqlalchemy.ext.asyncio import AsyncSession
 from datetime import timedelta
 
+from app import crud
 from app.core.security import create_access_token
+from app.models.enums import MessagePriority, MessageType
+
+
+async def get_csrf_auth(async_client: AsyncClient, user_id) -> tuple[dict[str, str], dict[str, str]]:
+    csrf_response = await async_client.get("/api/v1/csrf-token")
+    csrf_token = csrf_response.json()["csrf_token"]
+    csrf_cookie = csrf_response.cookies.get("fastapi-csrf-token")
+    access_token = create_access_token(str(user_id), timedelta(minutes=30))
+    return (
+        {
+            "access_token": access_token,
+            "fastapi-csrf-token": csrf_cookie,
+        },
+        {"X-CSRF-Token": csrf_token},
+    )
+
+
+async def create_unread_message(db_session: AsyncSession, sender, recipient, title: str = "CSRF既読テスト"):
+    office_id = sender.office_associations[0].office_id
+    message_data = {
+        "sender_staff_id": sender.id,
+        "office_id": office_id,
+        "recipient_ids": [recipient.id],
+        "message_type": MessageType.personal,
+        "priority": MessagePriority.normal,
+        "title": title,
+        "content": "CSRF cleanup regression test",
+    }
+    message = await crud.message.create_personal_message(db=db_session, obj_in=message_data)
+    await db_session.commit()
+    return message
 
 
 class TestCSRFProtection:
@@ -208,6 +240,137 @@ class TestCSRFProtection:
         # CSRFトークンがないため失敗するはず
         assert response.status_code == 403
         assert "CSRF" in response.json().get("detail", "").upper()
+
+    @pytest.mark.asyncio
+    async def test_message_mark_as_read_with_valid_csrf_token(
+        self,
+        async_client: AsyncClient,
+        db_session: AsyncSession,
+        owner_user_factory,
+        manager_user_factory,
+    ):
+        """メッセージ既読APIはCookie認証でも有効CSRF付きで成功する。"""
+        owner = await owner_user_factory()
+        manager = await manager_user_factory(office=owner.office_associations[0].office)
+        message = await create_unread_message(db_session, sender=owner, recipient=manager)
+        cookies, headers = await get_csrf_auth(async_client, manager.id)
+
+        response = await async_client.post(
+            f"/api/v1/messages/{message.id}/read",
+            cookies=cookies,
+            headers=headers,
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["is_read"] is True
+        assert data["read_at"] is not None
+
+    @pytest.mark.asyncio
+    async def test_message_mark_as_read_without_csrf_is_rejected_by_global_middleware(
+        self,
+        async_client: AsyncClient,
+        db_session: AsyncSession,
+        owner_user_factory,
+        manager_user_factory,
+    ):
+        """個別dependencyを削除してもglobal middlewareが既読APIを保護する。"""
+        owner = await owner_user_factory()
+        manager = await manager_user_factory(office=owner.office_associations[0].office)
+        message = await create_unread_message(db_session, sender=owner, recipient=manager)
+        access_token = create_access_token(str(manager.id), timedelta(minutes=30))
+
+        response = await async_client.post(
+            f"/api/v1/messages/{message.id}/read",
+            cookies={"access_token": access_token},
+        )
+
+        assert response.status_code == 403
+        assert response.json()["detail"] == "CSRF token validation failed"
+
+    @pytest.mark.asyncio
+    async def test_message_mark_all_read_with_valid_csrf_token(
+        self,
+        async_client: AsyncClient,
+        db_session: AsyncSession,
+        owner_user_factory,
+        manager_user_factory,
+    ):
+        """全既読APIはCookie認証でも有効CSRF付きで成功する。"""
+        owner = await owner_user_factory()
+        manager = await manager_user_factory(office=owner.office_associations[0].office)
+        for index in range(3):
+            await create_unread_message(
+                db_session,
+                sender=owner,
+                recipient=manager,
+                title=f"CSRF全既読テスト{index}",
+            )
+        cookies, headers = await get_csrf_auth(async_client, manager.id)
+
+        response = await async_client.post(
+            "/api/v1/messages/mark-all-read",
+            cookies=cookies,
+            headers=headers,
+        )
+
+        assert response.status_code == 200
+        assert response.json()["updated_count"] == 3
+
+    @pytest.mark.asyncio
+    async def test_admin_announcement_create_with_valid_csrf_token(
+        self,
+        async_client: AsyncClient,
+        db_session: AsyncSession,
+        app_admin_user_factory,
+        owner_user_factory,
+    ):
+        """app_adminのお知らせ作成APIはCookie認証でも有効CSRF付きで成功する。"""
+        app_admin = await app_admin_user_factory()
+        await owner_user_factory()
+        cookies, headers = await get_csrf_auth(async_client, app_admin.id)
+
+        response = await async_client.post(
+            "/api/v1/admin/announcements",
+            json={
+                "title": "CSRFお知らせ",
+                "content": "CSRF cleanup regression test",
+                "priority": "normal",
+            },
+            cookies=cookies,
+            headers=headers,
+        )
+
+        assert response.status_code == 201
+        data = response.json()
+        assert data["title"] == "CSRFお知らせ"
+        assert data["message_type"] == "announcement"
+        assert data["recipient_count"] >= 1
+
+    @pytest.mark.asyncio
+    async def test_admin_announcement_without_csrf_is_rejected_by_global_middleware(
+        self,
+        async_client: AsyncClient,
+        app_admin_user_factory,
+        owner_user_factory,
+    ):
+        """個別dependencyを削除してもglobal middlewareがapp_adminお知らせ作成を保護する。"""
+        app_admin = await app_admin_user_factory()
+        await owner_user_factory()
+        access_token = create_access_token(str(app_admin.id), timedelta(minutes=30))
+
+        response = await async_client.post(
+            "/api/v1/admin/announcements",
+            json={
+                "title": "CSRFなしお知らせ",
+                "content": "CSRF cleanup regression test",
+                "priority": "normal",
+            },
+            cookies={"access_token": access_token},
+        )
+
+        assert response.status_code == 403
+        assert response.json()["detail"] == "CSRF token validation failed"
 
     @pytest.mark.asyncio
     async def test_login_is_not_blocked_by_csrf_when_stale_access_cookie_exists(


### PR DESCRIPTION
## Summary
- メッセージ、Officeの更新、およびアプリ管理アナウンスから、エンドポイントレベルのCSRF依存関係を削除する
- 状態を変更するエンドポイントについては、グローバルなCookie認証用CSRFミドルウェアを利用する
- メッセージの閲覧、すべて既読にする操作、およびアプリ管理アナウンスにおいて、CSRFの成功および拒否に対する回帰テストのカバレッジを追加する
- アプリ管理アナウンスの受信者に対するOfficeの関連付けをイージーロードし、nullのoffice_idが挿入されるのを防ぐ

## Validation
- docker compose exec -T backend pytest tests/api/v1/test_csrf_protection.py tests/security/test_deploy_safety_guards.py
- docker compose exec -T backend pytest tests/api/v1/test_messages_api.py
- manual: login OK
- manual: logout OK
- manual: MFA OK
- manual: message sending OK
- manual: PDF upload OK

Closes nto300002/keikakun_app#167