### PR TITLE
[codex] Fix office active query CD test failure

### DIFF
--- a/app/crud/crud_office.py
+++ b/app/crud/crud_office.py
@@ -145,17 +145,20 @@ class CRUDOffice(CRUDBase[Office, OfficeCreate, OfficeUpdate]):
         db: AsyncSession,
         *,
         skip: int = 0,
-        limit: int = 100
+        limit: Optional[int] = 100
     ) -> List[Office]:
         """
         アクティブな（論理削除されていない）事務所一覧を取得
         """
-        result = await db.execute(
+        stmt = (
             select(Office)
             .where(Office.is_deleted == False)  # noqa: E712
             .offset(skip)
-            .limit(limit)
         )
+        if limit is not None:
+            stmt = stmt.limit(limit)
+
+        result = await db.execute(stmt)
         return list(result.scalars().all())
 
     async def get_active_by_id(

--- a/tests/crud/test_crud_office_soft_delete.py
+++ b/tests/crud/test_crud_office_soft_delete.py
@@ -118,7 +118,8 @@ class TestOfficeActiveQuery:
 
         # アクティブな事務所のみ取得
         active_offices = await crud_office.get_active_offices(
-            db=db_session
+            db=db_session,
+            limit=None,
         )
 
         # office1は含まれず、office2は含まれる


### PR DESCRIPTION
## Summary
- `crud_office.get_active_offices` で、`limit=None` を指定することで、デフォルトのページネーション制限を無効にできるようにする。
- アクティブオフィスのソフト削除テストを更新し、デフォルトの最初の 100 行に依存するのではなく、アクティブオフィスの全セットを検証するようにする。

## Root cause
テストセッション中、CDランには100以上のアクティブなオフィス行が利用可能でした。get_active_officesのデフォルト設定はlimit=100であるため、テストによって作成されたオフィスが返されるページに確実に表示されるとは限りませんでした。

## Validation
- docker compose exec backend pytest tests/crud/test_crud_office_soft_delete.py::TestOfficeActiveQuery::test_get_active_offices
- docker compose exec backend pytest tests/crud/test_crud_office_soft_delete.py