### PR TITLE
Fix app-admin announcements and inquiry replies

### DIFF
--- a/app/api/v1/endpoints/admin_announcements.py
+++ b/app/api/v1/endpoints/admin_announcements.py
@@ -3,18 +3,18 @@ app_admin用お知らせAPIエンドポイント
 
 全スタッフへのお知らせ（MessageType.announcement）を管理
 """
-from fastapi import APIRouter, Depends, Query, Request, HTTPException, status
+from fastapi import APIRouter, Depends, Query, HTTPException, status
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy import select, func
 from sqlalchemy.orm import selectinload
 
 from app.api.deps import get_db, require_app_admin, validate_csrf
+from app.models.office import OfficeStaff
 from app.models.staff import Staff
 from app.models.message import Message
 from app.models.enums import MessageType
 from app.schemas.message import MessageResponse, MessageAnnouncementCreate, MessageDetailResponse
 from app.crud.crud_message import crud_message
-from app import crud
 
 router = APIRouter()
 
@@ -79,7 +79,6 @@ async def get_announcements(
 @router.post("", response_model=MessageDetailResponse, status_code=status.HTTP_201_CREATED)
 async def send_announcement_to_all(
     *,
-    request: Request,
     db: AsyncSession = Depends(get_db),
     current_user: Staff = Depends(require_app_admin),
     message_in: MessageAnnouncementCreate,
@@ -92,34 +91,43 @@ async def send_announcement_to_all(
     - 全事務所の全スタッフに一斉送信
     - CSRF保護: Cookie認証の場合はCSRFトークンが必要
     """
-    # 全スタッフを取得（app_admin自身を除く）
-    all_staff_query = (
-        select(Staff)
+    # 全スタッフIDを取得（app_admin自身を除く）
+    recipient_ids_query = (
+        select(Staff.id)
         .where(
             Staff.is_deleted == False,  # noqa: E712
             Staff.id != current_user.id
         )
     )
-    all_staff_result = await db.execute(all_staff_query)
-    all_staff = list(all_staff_result.scalars().all())
+    recipient_ids_result = await db.execute(recipient_ids_query)
+    recipient_ids = list(recipient_ids_result.scalars().all())
 
-    if not all_staff:
+    if not recipient_ids:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail="送信先のスタッフが存在しません"
         )
 
-    # 事務所IDを取得（最初のスタッフの事務所、またはNone）
-    office_id = None
-    if all_staff and all_staff[0].office_associations:
-        office_id = all_staff[0].office_associations[0].office_id
+    # Message.office_id は現行DBで必須のため、対象スタッフの所属事務所をSQLで取得する。
+    office_id_query = (
+        select(OfficeStaff.office_id)
+        .where(OfficeStaff.staff_id.in_(recipient_ids))
+        .order_by(OfficeStaff.is_primary.desc(), OfficeStaff.created_at.asc())
+        .limit(1)
+    )
+    office_id_result = await db.execute(office_id_query)
+    office_id = office_id_result.scalar_one_or_none()
 
-    recipient_ids = [staff.id for staff in all_staff]
+    if office_id is None:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="送信先スタッフの所属事務所が存在しません"
+        )
 
     # お知らせを作成
     message_data = {
         "sender_staff_id": current_user.id,
-        "office_id": office_id,  # app_adminの場合はNULLでも良い
+        "office_id": office_id,
         "recipient_ids": recipient_ids,
         "message_type": MessageType.announcement,
         "priority": message_in.priority,

--- a/app/api/v1/endpoints/admin_inquiries.py
+++ b/app/api/v1/endpoints/admin_inquiries.py
@@ -225,27 +225,26 @@ async def reply_to_inquiry(
         - メール送信フラグがTrueの場合は実際にメールを送信
     """
     try:
-        # メール送信用にcommit前に問い合わせ情報を取得
+        # 返信はアプリ内通知とメールを連動させる。
+        # sender_email が存在する場合は、リクエストの send_email 値にかかわらずメール送信対象にする。
         email_data = None
-        if reply_in.send_email:
-            inquiry = await crud_inquiry.get_inquiry_by_id(db=db, inquiry_id=inquiry_id)
-            if inquiry and inquiry.sender_email:
-                # メール送信に必要な情報を事前に取得
-                original_message = inquiry.message
-                email_data = {
-                    "recipient_email": inquiry.sender_email,
-                    "recipient_name": inquiry.sender_name,
-                    "inquiry_title": original_message.title if original_message else "問い合わせ",
-                    "inquiry_created_at": inquiry.created_at.isoformat() if inquiry.created_at else "",
-                    "reply_content": reply_in.body,
-                }
+        inquiry = await crud_inquiry.get_inquiry_by_id(db=db, inquiry_id=inquiry_id)
+        if inquiry and inquiry.sender_email:
+            original_message = inquiry.message
+            email_data = {
+                "recipient_email": inquiry.sender_email,
+                "recipient_name": inquiry.sender_name,
+                "inquiry_title": original_message.title if original_message else "問い合わせ",
+                "inquiry_created_at": inquiry.created_at.isoformat() if inquiry.created_at else "",
+                "reply_content": reply_in.body,
+            }
 
         reply_message = await crud_inquiry.create_reply(
             db=db,
             inquiry_id=inquiry_id,
             reply_staff_id=current_user.id,
             reply_content=reply_in.body,
-            send_email=reply_in.send_email
+            send_email=email_data is not None
         )
 
         # コミット前に必要な値を取得（重要！）
@@ -271,10 +270,10 @@ async def reply_to_inquiry(
                 logger.error("問い合わせ返信メール送信に失敗: %s", type(email_error).__name__)
 
         # メッセージ内容を決定
-        if reply_in.send_email:
-            message_text = "返信を送信しました（メール送信を含む）"
+        if email_data:
+            message_text = "返信を送信しました（アプリ内通知とメールを連動）"
         else:
-            message_text = "返信を送信しました（内部通知のみ）"
+            message_text = "返信を送信しました（アプリ内通知のみ）"
 
         return InquiryReplyResponse(
             id=reply_message_id,

--- a/tests/api/v1/test_admin_announcements.py
+++ b/tests/api/v1/test_admin_announcements.py
@@ -1,0 +1,147 @@
+from datetime import timedelta
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy import select, update
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.security import create_access_token
+from app.models.enums import StaffRole
+from app.models.message import Message, MessageRecipient
+from app.models.staff import Staff
+
+
+def _auth_cookies(access_token: str, csrf_cookie: str | None = None) -> dict[str, str]:
+    cookies = {"access_token": access_token}
+    if csrf_cookie is not None:
+        cookies["fastapi-csrf-token"] = csrf_cookie
+    return cookies
+
+
+async def _csrf(async_client: AsyncClient) -> tuple[dict[str, str], str]:
+    csrf_response = await async_client.get("/api/v1/csrf-token")
+    csrf_response.raise_for_status()
+    return (
+        {"X-CSRF-Token": csrf_response.json()["csrf_token"]},
+        csrf_response.cookies.get("fastapi-csrf-token"),
+    )
+
+
+@pytest.mark.asyncio
+async def test_app_admin_send_announcement_with_valid_csrf_returns_created(
+    async_client: AsyncClient,
+    db_session: AsyncSession,
+    app_admin_user_factory,
+    office_factory,
+    staff_factory,
+):
+    app_admin = await app_admin_user_factory()
+    another_app_admin = await app_admin_user_factory()
+    office = await office_factory()
+    recipient = await staff_factory(office_id=office.id, role=StaffRole.employee)
+    deleted_recipient = await staff_factory(office_id=office.id, role=StaffRole.employee)
+    deleted_recipient.is_deleted = True
+    await db_session.flush()
+    headers, csrf_cookie = await _csrf(async_client)
+    access_token = create_access_token(str(app_admin.id), timedelta(minutes=30))
+
+    response = await async_client.post(
+        "/api/v1/admin/announcements",
+        json={"title": "全体通知", "content": "本文です"},
+        cookies=_auth_cookies(access_token, csrf_cookie),
+        headers=headers,
+    )
+
+    assert response.status_code == 201
+    data = response.json()
+    assert data["title"] == "全体通知"
+    assert data["content"] == "本文です"
+    assert data["recipient_count"] >= 1
+    assert data["office_id"] == str(office.id)
+
+    message = await db_session.get(Message, data["id"])
+    assert message is not None
+    recipients_result = await db_session.execute(
+        select(MessageRecipient).where(MessageRecipient.message_id == message.id)
+    )
+    recipient_ids = {
+        message_recipient.recipient_staff_id
+        for message_recipient in recipients_result.scalars().all()
+    }
+    assert recipient.id in recipient_ids
+    assert another_app_admin.id in recipient_ids
+    assert app_admin.id not in recipient_ids
+    assert deleted_recipient.id not in recipient_ids
+
+
+@pytest.mark.asyncio
+async def test_app_admin_send_announcement_does_not_lazy_load_staff_office(
+    async_client: AsyncClient,
+    app_admin_user_factory,
+    office_factory,
+    staff_factory,
+):
+    app_admin = await app_admin_user_factory()
+    office = await office_factory()
+    await staff_factory(office_id=office.id, role=StaffRole.employee)
+    headers, csrf_cookie = await _csrf(async_client)
+    access_token = create_access_token(str(app_admin.id), timedelta(minutes=30))
+
+    response = await async_client.post(
+        "/api/v1/admin/announcements",
+        json={"title": "遅延ロード回避", "content": "本文です"},
+        cookies=_auth_cookies(access_token, csrf_cookie),
+        headers=headers,
+    )
+
+    assert response.status_code == 201
+    assert response.json()["office_id"] == str(office.id)
+
+
+@pytest.mark.asyncio
+async def test_app_admin_send_announcement_without_recipients_returns_400(
+    async_client: AsyncClient,
+    db_session: AsyncSession,
+    app_admin_user_factory,
+):
+    app_admin = await app_admin_user_factory()
+    await db_session.execute(
+        update(Staff)
+        .where(Staff.id != app_admin.id)
+        .values(is_deleted=True)
+    )
+    await db_session.flush()
+    headers, csrf_cookie = await _csrf(async_client)
+    access_token = create_access_token(str(app_admin.id), timedelta(minutes=30))
+
+    response = await async_client.post(
+        "/api/v1/admin/announcements",
+        json={"title": "送信先なし", "content": "本文です"},
+        cookies=_auth_cookies(access_token, csrf_cookie),
+        headers=headers,
+    )
+
+    assert response.status_code == 400
+    assert response.json()["detail"] == "送信先のスタッフが存在しません"
+
+
+@pytest.mark.asyncio
+async def test_app_admin_send_announcement_requires_csrf_for_cookie_auth(
+    async_client: AsyncClient,
+    app_admin_user_factory,
+    office_factory,
+    staff_factory,
+):
+    app_admin = await app_admin_user_factory()
+    office = await office_factory()
+    await staff_factory(office_id=office.id, role=StaffRole.employee)
+    access_token = create_access_token(str(app_admin.id), timedelta(minutes=30))
+
+    response = await async_client.post(
+        "/api/v1/admin/announcements",
+        json={"title": "CSRFなし", "content": "本文です"},
+        cookies=_auth_cookies(access_token),
+    )
+
+    assert response.status_code == 403
+    assert "CSRF" in response.json()["detail"].upper()

--- a/tests/api/v1/test_inquiry_endpoints.py
+++ b/tests/api/v1/test_inquiry_endpoints.py
@@ -729,7 +729,7 @@ class TestAdminInquiryReplyEndpoint:
         # Assert
         assert response.status_code == 200
         data = response.json()
-        assert "メール送信を含む" in data["message"]
+        assert data["message"] == "返信を送信しました（アプリ内通知とメールを連動）"
 
         # delivery_logに記録されていることを確認
         await db_session.refresh(inquiry)
@@ -737,6 +737,129 @@ class TestAdminInquiryReplyEndpoint:
         assert len(inquiry.delivery_log) > 0
         assert inquiry.delivery_log[0]["action"] == "reply_email_queued"
         assert inquiry.delivery_log[0]["recipient"] == "sender@example.com"
+
+    async def test_reply_to_inquiry_sends_email_when_sender_email_exists_even_if_flag_false(
+        self,
+        async_client: AsyncClient,
+        app_admin_user_factory,
+        employee_user_factory,
+        db_session: AsyncSession,
+        csrf_headers,
+        monkeypatch
+    ):
+        """
+        返信はアプリ内通知とメールを連動させる。
+
+        POST /api/v1/admin/inquiries/{inquiry_id}/reply
+        - sender_email がある場合、send_email=false でもメール送信対象
+        - delivery_log にメール送信キュー記録が残る
+        """
+        app_admin = await app_admin_user_factory()
+        sender = await employee_user_factory()
+        from app import crud
+
+        office_id = sender.office_associations[0].office.id if sender.office_associations else None
+        inquiry = await crud.inquiry.create_inquiry(
+            db=db_session,
+            sender_staff_id=sender.id,
+            office_id=office_id,
+            title="メール連動テスト",
+            content="メール連動テスト内容",
+            priority=InquiryPriority.normal,
+            admin_recipient_ids=[app_admin.id],
+            sender_name="送信 太郎",
+            sender_email="sender-linked@example.com",
+            is_test_data=True
+        )
+        await db_session.commit()
+
+        sent_emails = []
+
+        async def fake_send_inquiry_reply_email(**kwargs):
+            sent_emails.append(kwargs)
+
+        monkeypatch.setattr(
+            "app.core.mail.send_inquiry_reply_email",
+            fake_send_inquiry_reply_email
+        )
+
+        access_token = create_access_token(
+            str(app_admin.id),
+            timedelta(minutes=settings.ACCESS_TOKEN_EXPIRE_MINUTES)
+        )
+
+        response = await async_client.post(
+            f"/api/v1/admin/inquiries/{inquiry.id}/reply",
+            json={"body": "メール連動の返信内容です。", "send_email": False},
+            cookies={"access_token": access_token},
+            headers=csrf_headers,
+        )
+
+        assert response.status_code == 200
+        assert response.json()["message"] == "返信を送信しました（アプリ内通知とメールを連動）"
+        assert sent_emails
+        assert sent_emails[0]["recipient_email"] == "sender-linked@example.com"
+
+        await db_session.refresh(inquiry)
+        assert inquiry.delivery_log is not None
+        assert inquiry.delivery_log[0]["action"] == "reply_email_queued"
+        assert inquiry.delivery_log[0]["recipient"] == "sender-linked@example.com"
+
+    async def test_reply_to_inquiry_succeeds_when_linked_email_sending_fails(
+        self,
+        async_client: AsyncClient,
+        app_admin_user_factory,
+        employee_user_factory,
+        db_session: AsyncSession,
+        csrf_headers,
+        monkeypatch
+    ):
+        """
+        メール送信失敗は返信処理を失敗させない。
+        """
+        app_admin = await app_admin_user_factory()
+        sender = await employee_user_factory()
+        from app import crud
+
+        office_id = sender.office_associations[0].office.id if sender.office_associations else None
+        inquiry = await crud.inquiry.create_inquiry(
+            db=db_session,
+            sender_staff_id=sender.id,
+            office_id=office_id,
+            title="メール失敗テスト",
+            content="メール失敗テスト内容",
+            priority=InquiryPriority.normal,
+            admin_recipient_ids=[app_admin.id],
+            sender_email="sender-fail@example.com",
+            is_test_data=True
+        )
+        await db_session.commit()
+
+        async def fail_send_inquiry_reply_email(**kwargs):
+            raise RuntimeError("mail failure")
+
+        monkeypatch.setattr(
+            "app.core.mail.send_inquiry_reply_email",
+            fail_send_inquiry_reply_email
+        )
+
+        access_token = create_access_token(
+            str(app_admin.id),
+            timedelta(minutes=settings.ACCESS_TOKEN_EXPIRE_MINUTES)
+        )
+
+        response = await async_client.post(
+            f"/api/v1/admin/inquiries/{inquiry.id}/reply",
+            json={"body": "メール送信が失敗しても返信は成功します。", "send_email": False},
+            cookies={"access_token": access_token},
+            headers=csrf_headers,
+        )
+
+        assert response.status_code == 200
+        assert response.json()["message"] == "返信を送信しました（アプリ内通知とメールを連動）"
+
+        await db_session.refresh(inquiry)
+        assert inquiry.status == InquiryStatus.answered
 
     async def test_reply_to_inquiry_not_found(
         self,


### PR DESCRIPTION
## Summary
- 非同期の遅延読み込みを回避し、現在の受信者ポリシーを維持することで、アプリ管理者の告知POSTを修正
- 送信者のメールアドレスが存在する場合、問い合わせへの返信をアプリの通知およびメールにリンクさせる
- 告知の受信者、CSRF、受信者不在時の処理、および問い合わせへの返信メールの動作に関する回帰テストを追加

## Tests
- docker exec keikakun_app-backend-1 pytest tests/api/v1/test_inquiry_endpoints.py::TestAdminInquiryReplyEndpoint tests/api/v1/test_admin_announcements.py -q
- git diff --check