### PR TITLE
Add support plan .ics export

### DIFF
--- a/app/api/v1/endpoints/calendar.py
+++ b/app/api/v1/endpoints/calendar.py
@@ -1,22 +1,60 @@
 """カレンダー設定APIエンドポイント"""
+from datetime import date, timedelta
 from typing import Any
 from uuid import UUID
 
-from fastapi import APIRouter, Depends, HTTPException, status
-from fastapi.responses import JSONResponse
+from fastapi import APIRouter, Depends, HTTPException, Query, status
+from fastapi.responses import JSONResponse, Response
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app import models
 from app.api import deps
 from app.services.calendar_service import calendar_service
+from app.services.ics_export_service import ics_export_service
 from app.schemas.calendar_account import (
     CalendarSetupRequest,
     CalendarSetupResponse,
     OfficeCalendarAccountResponse
 )
+from app.schemas.calendar_event import CalendarEventResponse
 from app.messages import ja
 
 router = APIRouter()
+
+
+def _get_primary_office_id(current_user: models.Staff) -> UUID:
+    office_associations = getattr(current_user, "office_associations", None)
+    if not office_associations:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail=ja.RECIPIENT_MUST_HAVE_OFFICE,
+        )
+
+    primary_association = next(
+        (assoc for assoc in office_associations if assoc.is_primary),
+        office_associations[0],
+    )
+    return primary_association.office_id
+
+
+def _resolve_export_range(from_date: date | None, to_date: date | None) -> tuple[date, date]:
+    today = date.today()
+    resolved_from = from_date or today
+    resolved_to = to_date or (resolved_from + timedelta(days=183))
+
+    if resolved_to < resolved_from:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="to_date は from_date 以降の日付を指定してください",
+        )
+
+    if (resolved_to - resolved_from).days > 365:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=".ics の出力期間は最大1年までです",
+        )
+
+    return resolved_from, resolved_to
 
 
 @router.post("/setup", response_model=CalendarSetupResponse, status_code=status.HTTP_201_CREATED)
@@ -145,6 +183,62 @@ async def get_calendar_by_office(
         )
 
     return OfficeCalendarAccountResponse.model_validate(account)
+
+
+@router.get("/events", response_model=list[CalendarEventResponse])
+async def get_calendar_events(
+    *,
+    db: AsyncSession = Depends(deps.get_db),
+    current_user: models.Staff = Depends(deps.get_current_user),
+    from_date: date | None = Query(default=None),
+    to_date: date | None = Query(default=None),
+    event_type: models.CalendarEventType | None = Query(default=None),
+    recipient_id: UUID | None = Query(default=None),
+) -> Any:
+    """アプリ内期限カレンダーのイベント一覧を取得する。"""
+    office_id = _get_primary_office_id(current_user)
+    events = await calendar_service.get_deadline_events(
+        db=db,
+        office_id=office_id,
+        from_date=from_date,
+        to_date=to_date,
+        event_type=event_type,
+        recipient_id=recipient_id,
+    )
+    return [CalendarEventResponse.model_validate(event) for event in events]
+
+
+@router.get("/export.ics", response_class=Response)
+async def export_calendar_ics(
+    *,
+    db: AsyncSession = Depends(deps.get_db),
+    current_user: models.Staff = Depends(deps.get_current_user),
+    from_date: date | None = Query(default=None),
+    to_date: date | None = Query(default=None),
+    event_type: models.CalendarEventType | None = Query(default=None),
+    recipient_id: UUID | None = Query(default=None),
+) -> Response:
+    """支援計画ページ向けに期限イベントを .ics として出力する。"""
+    office_id = _get_primary_office_id(current_user)
+    resolved_from, resolved_to = _resolve_export_range(from_date, to_date)
+
+    events = await calendar_service.get_deadline_events(
+        db=db,
+        office_id=office_id,
+        from_date=resolved_from,
+        to_date=resolved_to,
+        event_type=event_type,
+        recipient_id=recipient_id,
+    )
+    ics_body = ics_export_service.build_calendar(events=events)
+    filename = ics_export_service.build_filename(today=date.today())
+    return Response(
+        content=ics_body,
+        media_type="text/calendar; charset=utf-8",
+        headers={
+            "Content-Disposition": f'attachment; filename="{filename}"',
+        },
+    )
 
 
 @router.get("/{account_id}", response_model=OfficeCalendarAccountResponse)

--- a/app/services/ics_export_service.py
+++ b/app/services/ics_export_service.py
@@ -1,0 +1,97 @@
+from datetime import date, datetime, timezone
+from uuid import UUID
+
+from app.models.calendar_events import CalendarEvent
+
+
+def _escape_ics_text(value: str | None) -> str:
+    if not value:
+        return ""
+    return (
+        value
+        .replace("\\", "\\\\")
+        .replace("\n", "\\n")
+        .replace(",", "\\,")
+        .replace(";", "\\;")
+    )
+
+
+def _format_ics_datetime(value: datetime) -> str:
+    if value.tzinfo is None:
+        value = value.replace(tzinfo=timezone.utc)
+    return value.astimezone(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+
+
+def _fold_ics_line(line: str) -> list[str]:
+    """RFC 5545 line folding. Keep this byte-aware for Japanese text."""
+    max_bytes = 75
+    encoded = line.encode("utf-8")
+    if len(encoded) <= max_bytes:
+        return [line]
+
+    folded: list[str] = []
+    current = ""
+    current_len = 0
+    for char in line:
+        char_len = len(char.encode("utf-8"))
+        if current and current_len + char_len > max_bytes:
+            folded.append(current)
+            current = f" {char}"
+            current_len = 1 + char_len
+        else:
+            current += char
+            current_len += char_len
+    if current:
+        folded.append(current)
+    return folded
+
+
+class IcsExportService:
+    def build_calendar(self, *, events: list[CalendarEvent]) -> str:
+        generated_at = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+        lines = [
+            "BEGIN:VCALENDAR",
+            "VERSION:2.0",
+            "PRODID:-//Keikakun//Deadline Calendar//JA",
+            "CALSCALE:GREGORIAN",
+            "METHOD:PUBLISH",
+        ]
+
+        for event in events:
+            lines.extend(self._build_event_lines(event=event, generated_at=generated_at))
+
+        lines.append("END:VCALENDAR")
+        folded_lines: list[str] = []
+        for line in lines:
+            folded_lines.extend(_fold_ics_line(line))
+        return "\r\n".join(folded_lines) + "\r\n"
+
+    def _build_event_lines(self, *, event: CalendarEvent, generated_at: str) -> list[str]:
+        description_parts = []
+        if event.event_description:
+            description_parts.append(event.event_description)
+        if event.welfare_recipient:
+            full_name = " ".join(
+                part for part in [event.welfare_recipient.last_name, event.welfare_recipient.first_name] if part
+            ).strip()
+            if full_name:
+                description_parts.append(f"利用者: {full_name}")
+
+        description = "\n".join(description_parts)
+        return [
+            "BEGIN:VEVENT",
+            f"UID:{event.id}@keikakun",
+            f"DTSTAMP:{generated_at}",
+            f"DTSTART:{_format_ics_datetime(event.event_start_datetime)}",
+            f"DTEND:{_format_ics_datetime(event.event_end_datetime)}",
+            f"SUMMARY:{_escape_ics_text(event.event_title)}",
+            f"DESCRIPTION:{_escape_ics_text(description)}",
+            f"CATEGORIES:{_escape_ics_text(event.event_type.value)}",
+            "END:VEVENT",
+        ]
+
+    def build_filename(self, *, today: date) -> str:
+        return f"keikakun-calendar-{today.strftime('%Y%m%d')}.ics"
+
+
+ics_export_service = IcsExportService()

--- a/tests/api/v1/test_calendar.py
+++ b/tests/api/v1/test_calendar.py
@@ -7,13 +7,21 @@ from httpx import AsyncClient
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy import select
 import uuid
-from datetime import timedelta
+from datetime import datetime, timedelta, timezone
 from unittest.mock import patch
 
+from app.models.calendar_events import CalendarEvent
 from app.models.office import Office, OfficeStaff
 from app.models.staff import Staff
+from app.models.support_plan_cycle import SupportPlanCycle
 from app.models.calendar_account import OfficeCalendarAccount
-from app.models.enums import StaffRole, OfficeType, CalendarConnectionStatus
+from app.models.enums import (
+    StaffRole,
+    OfficeType,
+    CalendarConnectionStatus,
+    CalendarEventType,
+    CalendarSyncStatus,
+)
 from app import crud
 from app.core.security import create_access_token
 
@@ -253,6 +261,206 @@ class TestSetupCalendar:
 
         # Assert
         assert response.status_code == 401
+
+
+class TestGetCalendarEvents:
+    async def test_get_events_returns_only_current_office_events(
+        self,
+        async_client: AsyncClient,
+        db_session: AsyncSession,
+        owner_user_factory,
+        office_factory,
+        welfare_recipient_factory,
+    ):
+        owner = await owner_user_factory()
+        office = owner.office_associations[0].office
+        other_owner = await owner_user_factory()
+        other_office = other_owner.office_associations[0].office
+        recipient = await welfare_recipient_factory(office_id=office.id)
+        other_recipient = await welfare_recipient_factory(office_id=other_office.id)
+        cycle = SupportPlanCycle(office_id=office.id, welfare_recipient_id=recipient.id)
+        other_cycle = SupportPlanCycle(office_id=other_office.id, welfare_recipient_id=other_recipient.id)
+        db_session.add_all([cycle, other_cycle])
+        await db_session.flush()
+        db_session.add_all([
+            CalendarEvent(
+                office_id=office.id,
+                welfare_recipient_id=recipient.id,
+                support_plan_cycle_id=cycle.id,
+                event_type=CalendarEventType.renewal_deadline,
+                google_calendar_id="local-calendar",
+                event_title="自事業所イベント",
+                event_start_datetime=datetime(2026, 8, 1, 9, 0, tzinfo=timezone.utc),
+                event_end_datetime=datetime(2026, 8, 1, 18, 0, tzinfo=timezone.utc),
+                sync_status=CalendarSyncStatus.pending,
+            ),
+            CalendarEvent(
+                office_id=other_office.id,
+                welfare_recipient_id=other_recipient.id,
+                support_plan_cycle_id=other_cycle.id,
+                event_type=CalendarEventType.renewal_deadline,
+                google_calendar_id="local-calendar",
+                event_title="他事業所イベント",
+                event_start_datetime=datetime(2026, 8, 1, 9, 0, tzinfo=timezone.utc),
+                event_end_datetime=datetime(2026, 8, 1, 18, 0, tzinfo=timezone.utc),
+                sync_status=CalendarSyncStatus.pending,
+            ),
+        ])
+        await db_session.flush()
+
+        headers = {"Authorization": f"Bearer {create_access_token(str(owner.id), timedelta(minutes=30))}"}
+        response = await async_client.get("/api/v1/calendar/events", headers=headers)
+
+        assert response.status_code == 200
+        data = response.json()
+        assert [event["event_title"] for event in data] == ["自事業所イベント"]
+        assert data[0]["welfare_recipient_id"] == str(recipient.id)
+
+    async def test_get_events_filters_by_type_recipient_and_date_range(
+        self,
+        async_client: AsyncClient,
+        db_session: AsyncSession,
+        owner_user_factory,
+        welfare_recipient_factory,
+    ):
+        owner = await owner_user_factory()
+        office = owner.office_associations[0].office
+        recipient = await welfare_recipient_factory(office_id=office.id)
+        other_recipient = await welfare_recipient_factory(office_id=office.id)
+        cycle = SupportPlanCycle(office_id=office.id, welfare_recipient_id=recipient.id)
+        other_cycle = SupportPlanCycle(office_id=office.id, welfare_recipient_id=other_recipient.id)
+        db_session.add_all([cycle, other_cycle])
+        await db_session.flush()
+        db_session.add_all([
+            CalendarEvent(
+                office_id=office.id,
+                welfare_recipient_id=recipient.id,
+                support_plan_cycle_id=cycle.id,
+                event_type=CalendarEventType.renewal_deadline,
+                google_calendar_id="local-calendar",
+                event_title="対象イベント",
+                event_start_datetime=datetime(2026, 8, 10, 9, 0, tzinfo=timezone.utc),
+                event_end_datetime=datetime(2026, 8, 10, 18, 0, tzinfo=timezone.utc),
+                sync_status=CalendarSyncStatus.pending,
+            ),
+            CalendarEvent(
+                office_id=office.id,
+                welfare_recipient_id=other_recipient.id,
+                support_plan_cycle_id=other_cycle.id,
+                event_type=CalendarEventType.next_plan_start_date,
+                google_calendar_id="local-calendar",
+                event_title="対象外イベント",
+                event_start_datetime=datetime(2026, 9, 1, 9, 0, tzinfo=timezone.utc),
+                event_end_datetime=datetime(2026, 9, 1, 18, 0, tzinfo=timezone.utc),
+                sync_status=CalendarSyncStatus.pending,
+            ),
+        ])
+        await db_session.flush()
+
+        headers = {"Authorization": f"Bearer {create_access_token(str(owner.id), timedelta(minutes=30))}"}
+        response = await async_client.get(
+            "/api/v1/calendar/events",
+            params={
+                "from_date": "2026-08-01",
+                "to_date": "2026-08-31",
+                "event_type": CalendarEventType.renewal_deadline.value,
+                "recipient_id": str(recipient.id),
+            },
+            headers=headers,
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert [event["event_title"] for event in data] == ["対象イベント"]
+
+
+class TestExportCalendarIcs:
+    async def test_export_ics_returns_recipient_events_without_google_setup(
+        self,
+        async_client: AsyncClient,
+        db_session: AsyncSession,
+        owner_user_factory,
+        office_factory,
+        welfare_recipient_factory,
+    ):
+        owner = await owner_user_factory()
+        office = owner.office_associations[0].office
+        other_owner = await owner_user_factory()
+        other_office = other_owner.office_associations[0].office
+        recipient = await welfare_recipient_factory(office_id=office.id)
+        other_recipient = await welfare_recipient_factory(office_id=other_office.id)
+        cycle = SupportPlanCycle(office_id=office.id, welfare_recipient_id=recipient.id)
+        other_cycle = SupportPlanCycle(office_id=other_office.id, welfare_recipient_id=other_recipient.id)
+        db_session.add_all([cycle, other_cycle])
+        await db_session.flush()
+        db_session.add_all([
+            CalendarEvent(
+                office_id=office.id,
+                welfare_recipient_id=recipient.id,
+                support_plan_cycle_id=cycle.id,
+                event_type=CalendarEventType.renewal_deadline,
+                google_calendar_id="local-calendar",
+                event_title="更新期限,確認",
+                event_description="1行目\n2行目;注意\\確認",
+                event_start_datetime=datetime(2026, 8, 10, 9, 0, tzinfo=timezone.utc),
+                event_end_datetime=datetime(2026, 8, 10, 18, 0, tzinfo=timezone.utc),
+                sync_status=CalendarSyncStatus.pending,
+            ),
+            CalendarEvent(
+                office_id=other_office.id,
+                welfare_recipient_id=other_recipient.id,
+                support_plan_cycle_id=other_cycle.id,
+                event_type=CalendarEventType.renewal_deadline,
+                google_calendar_id="local-calendar",
+                event_title="他事業所イベント",
+                event_start_datetime=datetime(2026, 8, 10, 9, 0, tzinfo=timezone.utc),
+                event_end_datetime=datetime(2026, 8, 10, 18, 0, tzinfo=timezone.utc),
+                sync_status=CalendarSyncStatus.pending,
+            ),
+        ])
+        await db_session.flush()
+
+        headers = {"Authorization": f"Bearer {create_access_token(str(owner.id), timedelta(minutes=30))}"}
+        response = await async_client.get(
+            "/api/v1/calendar/export.ics",
+            params={
+                "from_date": "2026-08-01",
+                "to_date": "2026-08-31",
+                "recipient_id": str(recipient.id),
+            },
+            headers=headers,
+        )
+
+        assert response.status_code == 200
+        assert response.headers["content-type"].startswith("text/calendar")
+        assert "attachment; filename=\"keikakun-calendar-" in response.headers["content-disposition"]
+        body = response.text
+        assert "BEGIN:VCALENDAR" in body
+        assert "VERSION:2.0" in body
+        assert "METHOD:PUBLISH" in body
+        assert f"UID:{recipient.id}" not in body
+        assert "SUMMARY:更新期限\\,確認" in body
+        assert "DESCRIPTION:1行目\\n2行目\\;注意\\\\確認" in body
+        assert "DTSTART:20260810T090000Z" in body
+        assert "DTEND:20260810T180000Z" in body
+        assert "他事業所イベント" not in body
+
+    async def test_export_ics_rejects_more_than_one_year_range(
+        self,
+        async_client: AsyncClient,
+        owner_user_factory,
+    ):
+        owner = await owner_user_factory()
+        headers = {"Authorization": f"Bearer {create_access_token(str(owner.id), timedelta(minutes=30))}"}
+
+        response = await async_client.get(
+            "/api/v1/calendar/export.ics",
+            params={"from_date": "2026-01-01", "to_date": "2027-01-02"},
+            headers=headers,
+        )
+
+        assert response.status_code == 400
+        assert "1年" in response.json()["detail"]
 
 
 # --- カレンダー設定取得API (/api/v1/calendar/office/{office_id}) のテスト ---


### PR DESCRIPTION
## Summary
- Add GET /api/v1/calendar/export.ics for support-plan scoped deadline exports
- Generate RFC5545-style .ics from calendar_events with escaping and UTF-8-safe folding
- Support from_date, to_date, event_type, and recipient_id filters with max 1-year range
- Add regression tests for recipient-scoped export, cross-office exclusion, escaping, headers, and range validation

## Tests
- docker exec keikakun_app-backend-1 pytest tests/api/v1/test_calendar.py::TestGetCalendarEvents tests/api/v1/test_calendar.py::TestExportCalendarIcs -q
- git diff --check