### PR TITLE
[codex] Fix app-admin backend message regressions

### DIFF
--- a/app/api/v1/endpoints/admin_announcements.py
+++ b/app/api/v1/endpoints/admin_announcements.py
@@ -12,7 +12,7 @@ from app.api.deps import get_db, require_app_admin, validate_csrf
 from app.models.office import OfficeStaff
 from app.models.staff import Staff
 from app.models.message import Message
-from app.models.enums import MessageType
+from app.models.enums import MessageType, StaffRole
 from app.schemas.message import MessageResponse, MessageAnnouncementCreate, MessageDetailResponse
 from app.crud.crud_message import crud_message
 
@@ -91,12 +91,25 @@ async def send_announcement_to_all(
     - 全事務所の全スタッフに一斉送信
     - CSRF保護: Cookie認証の場合はCSRFトークンが必要
     """
-    # 全スタッフIDを取得（app_admin自身を除く）
+    # 全スタッフIDを取得（app_admin自身を除く）。
+    # 通常スタッフは verified かつ事業所所属あり、他 app_admin は事業所なしでも対象に含める。
+    office_membership_exists = (
+        select(OfficeStaff.staff_id)
+        .where(OfficeStaff.staff_id == Staff.id)
+        .exists()
+    )
     recipient_ids_query = (
         select(Staff.id)
         .where(
             Staff.is_deleted == False,  # noqa: E712
-            Staff.id != current_user.id
+            Staff.id != current_user.id,
+            (
+                (Staff.role == StaffRole.app_admin)
+                | (
+                    (Staff.is_email_verified == True)  # noqa: E712
+                    & office_membership_exists
+                )
+            )
         )
     )
     recipient_ids_result = await db.execute(recipient_ids_query)

--- a/app/api/v1/endpoints/admin_inquiries.py
+++ b/app/api/v1/endpoints/admin_inquiries.py
@@ -105,6 +105,7 @@ async def get_inquiries(
             priority=inquiry.priority,
             sender_name=inquiry.sender_name,
             sender_email=inquiry.sender_email,
+            sender_staff_id=inquiry.message.sender_staff_id if inquiry.message else None,
             assigned_staff_id=inquiry.assigned_staff_id,
             assigned_staff=assigned_staff_info,
             created_at=inquiry.created_at,

--- a/app/api/v1/endpoints/messages.py
+++ b/app/api/v1/endpoints/messages.py
@@ -179,6 +179,7 @@ async def get_inbox_messages(
     current_user: Staff = Depends(deps.get_current_user),
     is_read: Optional[bool] = Query(None, description="既読フィルタ"),
     message_type: Optional[MessageType] = Query(None, description="メッセージタイプフィルタ"),
+    message_types: Optional[List[MessageType]] = Query(None, description="複数メッセージタイプフィルタ"),
     skip: int = Query(0, ge=0, description="スキップ数"),
     limit: int = Query(20, ge=1, le=100, description="取得数上限")
 ):
@@ -195,6 +196,7 @@ async def get_inbox_messages(
         db=db,
         recipient_staff_id=current_user.id,
         message_type=message_type,
+        message_types=message_types,
         is_read=is_read,
         skip=skip,
         limit=limit

--- a/app/crud/crud_message.py
+++ b/app/crud/crud_message.py
@@ -4,7 +4,7 @@
 個別メッセージ、一斉通知、受信箱、統計などの操作を提供
 トランザクション管理とバルクインサートを適切に実装
 """
-from typing import List, Optional, Dict, Any
+from typing import List, Optional, Dict, Any, Sequence
 from uuid import UUID
 from datetime import datetime, timezone
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -226,6 +226,7 @@ class CRUDMessage(CRUDBase[Message, Dict[str, Any], Dict[str, Any]]):
         *,
         recipient_staff_id: UUID,
         message_type: Optional[MessageType] = None,
+        message_types: Optional[Sequence[MessageType]] = None,
         is_read: Optional[bool] = None,
         skip: int = 0,
         limit: int = 100
@@ -254,7 +255,9 @@ class CRUDMessage(CRUDBase[Message, Dict[str, Any], Dict[str, Any]]):
         )
 
         # フィルタを適用
-        if message_type is not None:
+        if message_types:
+            stmt = stmt.where(Message.message_type.in_(message_types))
+        elif message_type is not None:
             stmt = stmt.where(Message.message_type == message_type)
 
         if is_read is not None:

--- a/app/schemas/inquiry.py
+++ b/app/schemas/inquiry.py
@@ -201,6 +201,7 @@ class InquiryListItem(BaseModel):
     priority: InquiryPriority
     sender_name: Optional[str] = None
     sender_email: Optional[str] = None
+    sender_staff_id: Optional[uuid.UUID] = None
     assigned_staff_id: Optional[uuid.UUID] = None
     assigned_staff: Optional[StaffInfo] = None
     created_at: datetime

--- a/tests/api/v1/test_admin_announcements.py
+++ b/tests/api/v1/test_admin_announcements.py
@@ -8,6 +8,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.core.security import create_access_token
 from app.models.enums import StaffRole
 from app.models.message import Message, MessageRecipient
+from app.models.office import OfficeStaff
 from app.models.staff import Staff
 
 
@@ -72,6 +73,109 @@ async def test_app_admin_send_announcement_with_valid_csrf_returns_created(
     assert another_app_admin.id in recipient_ids
     assert app_admin.id not in recipient_ids
     assert deleted_recipient.id not in recipient_ids
+
+
+@pytest.mark.asyncio
+async def test_app_admin_send_announcement_excludes_unverified_and_office_less_non_admin_staff(
+    async_client: AsyncClient,
+    db_session: AsyncSession,
+    app_admin_user_factory,
+    employee_user_factory,
+    office_factory,
+    staff_factory,
+):
+    app_admin = await app_admin_user_factory()
+    other_app_admin = await app_admin_user_factory()
+    office = await office_factory()
+    verified_recipient = await staff_factory(
+        office_id=office.id,
+        role=StaffRole.employee,
+        is_email_verified=True,
+    )
+    unverified_recipient = await staff_factory(
+        office_id=office.id,
+        role=StaffRole.employee,
+        is_email_verified=False,
+    )
+    office_less_owner = await employee_user_factory(
+        role=StaffRole.owner,
+        with_office=False,
+        is_email_verified=True,
+    )
+    await db_session.flush()
+    headers, csrf_cookie = await _csrf(async_client)
+    access_token = create_access_token(str(app_admin.id), timedelta(minutes=30))
+
+    response = await async_client.post(
+        "/api/v1/admin/announcements",
+        json={"title": "対象ルール", "content": "本文です"},
+        cookies=_auth_cookies(access_token, csrf_cookie),
+        headers=headers,
+    )
+
+    assert response.status_code == 201
+    recipients_result = await db_session.execute(
+        select(MessageRecipient).where(MessageRecipient.message_id == response.json()["id"])
+    )
+    recipient_ids = {
+        message_recipient.recipient_staff_id
+        for message_recipient in recipients_result.scalars().all()
+    }
+    assert verified_recipient.id in recipient_ids
+    assert other_app_admin.id in recipient_ids
+    assert unverified_recipient.id not in recipient_ids
+    assert office_less_owner.id not in recipient_ids
+
+
+@pytest.mark.asyncio
+@pytest.mark.performance
+async def test_app_admin_send_announcement_handles_more_than_1000_recipients(
+    async_client: AsyncClient,
+    db_session: AsyncSession,
+    app_admin_user_factory,
+    office_factory,
+):
+    app_admin = await app_admin_user_factory()
+    office = await office_factory()
+    recipients = [
+        Staff(
+            first_name="大量",
+            last_name=f"送信{i}",
+            full_name=f"送信{i} 大量",
+            email=f"bulk-announcement-{i}@example.com",
+            hashed_password="test-password-hash",
+            role=StaffRole.employee,
+            is_email_verified=True,
+            is_test_data=True,
+        )
+        for i in range(1001)
+    ]
+    db_session.add_all(recipients)
+    await db_session.flush()
+    db_session.add_all(
+        [
+            OfficeStaff(
+                staff_id=recipient.id,
+                office_id=office.id,
+                is_primary=True,
+                is_test_data=True,
+            )
+            for recipient in recipients
+        ]
+    )
+    await db_session.flush()
+    headers, csrf_cookie = await _csrf(async_client)
+    access_token = create_access_token(str(app_admin.id), timedelta(minutes=30))
+
+    response = await async_client.post(
+        "/api/v1/admin/announcements",
+        json={"title": "大量送信", "content": "本文です"},
+        cookies=_auth_cookies(access_token, csrf_cookie),
+        headers=headers,
+    )
+
+    assert response.status_code == 201
+    assert response.json()["recipient_count"] >= 1001
 
 
 @pytest.mark.asyncio

--- a/tests/api/v1/test_admin_inquiry_reply_delivery.py
+++ b/tests/api/v1/test_admin_inquiry_reply_delivery.py
@@ -1,0 +1,148 @@
+from datetime import timedelta
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.security import create_access_token
+from app.models.enums import InquiryStatus, MessageType
+from app.models.message import MessageRecipient
+
+
+def _auth_headers(access_token: str) -> dict[str, str]:
+    return {"Authorization": f"Bearer {access_token}"}
+
+
+@pytest.mark.asyncio
+async def test_reply_to_logged_in_inquiry_creates_app_notification_and_sends_email(
+    async_client: AsyncClient,
+    db_session: AsyncSession,
+    app_admin_user_factory,
+    employee_user_factory,
+    inquiry_detail_factory,
+    mocker,
+):
+    app_admin = await app_admin_user_factory()
+    sender = await employee_user_factory(email="inquiry.sender@example.com")
+    inquiry = await inquiry_detail_factory(
+        sender_staff_id=sender.id,
+        sender_name=sender.full_name,
+        sender_email=sender.email,
+        title="ログイン済み問い合わせ",
+    )
+    send_email = mocker.patch(
+        "app.core.mail.send_inquiry_reply_email",
+        new_callable=mocker.AsyncMock,
+    )
+    access_token = create_access_token(str(app_admin.id), timedelta(minutes=30))
+
+    response = await async_client.post(
+        f"/api/v1/admin/inquiries/{inquiry.id}/reply",
+        json={"body": "返信本文", "send_email": False},
+        headers=_auth_headers(access_token),
+    )
+
+    assert response.status_code == 200
+    data = response.json()
+    assert "メール" in data["message"]
+    send_email.assert_awaited_once()
+    assert send_email.await_args.kwargs["recipient_email"] == sender.email
+
+    await db_session.refresh(inquiry)
+    assert inquiry.status == InquiryStatus.answered
+    assert inquiry.delivery_log
+    assert inquiry.delivery_log[-1]["action"] == "reply_email_queued"
+
+    recipients = await db_session.execute(
+        select(MessageRecipient)
+        .join(MessageRecipient.message)
+        .where(
+            MessageRecipient.recipient_staff_id == sender.id,
+            MessageRecipient.message.has(message_type=MessageType.inquiry_reply),
+        )
+    )
+    assert recipients.scalars().first() is not None
+
+
+@pytest.mark.asyncio
+async def test_reply_to_external_inquiry_sends_email_without_app_recipient(
+    async_client: AsyncClient,
+    db_session: AsyncSession,
+    app_admin_user_factory,
+    inquiry_detail_factory,
+    mocker,
+):
+    app_admin = await app_admin_user_factory()
+    inquiry = await inquiry_detail_factory(
+        sender_staff_id=None,
+        sender_name="外部 送信者",
+        sender_email="guest.reply@example.com",
+        title="外部問い合わせ",
+    )
+    send_email = mocker.patch(
+        "app.core.mail.send_inquiry_reply_email",
+        new_callable=mocker.AsyncMock,
+    )
+    access_token = create_access_token(str(app_admin.id), timedelta(minutes=30))
+
+    response = await async_client.post(
+        f"/api/v1/admin/inquiries/{inquiry.id}/reply",
+        json={"body": "外部返信", "send_email": False},
+        headers=_auth_headers(access_token),
+    )
+
+    assert response.status_code == 200
+    send_email.assert_awaited_once()
+
+    reply_recipients = await db_session.execute(
+        select(MessageRecipient)
+        .join(MessageRecipient.message)
+        .where(MessageRecipient.message.has(message_type=MessageType.inquiry_reply))
+    )
+    assert reply_recipients.scalars().all() == []
+
+
+@pytest.mark.asyncio
+async def test_reply_to_inquiry_without_email_uses_app_notification_only(
+    async_client: AsyncClient,
+    db_session: AsyncSession,
+    app_admin_user_factory,
+    employee_user_factory,
+    inquiry_detail_factory,
+    mocker,
+):
+    app_admin = await app_admin_user_factory()
+    sender = await employee_user_factory()
+    inquiry = await inquiry_detail_factory(
+        sender_staff_id=sender.id,
+        sender_name=sender.full_name,
+        title="メールなし問い合わせ",
+    )
+    inquiry.sender_email = None
+    await db_session.flush()
+    send_email = mocker.patch(
+        "app.core.mail.send_inquiry_reply_email",
+        new_callable=mocker.AsyncMock,
+    )
+    access_token = create_access_token(str(app_admin.id), timedelta(minutes=30))
+
+    response = await async_client.post(
+        f"/api/v1/admin/inquiries/{inquiry.id}/reply",
+        json={"body": "アプリ通知のみ", "send_email": True},
+        headers=_auth_headers(access_token),
+    )
+
+    assert response.status_code == 200
+    assert "アプリ内通知のみ" in response.json()["message"]
+    send_email.assert_not_awaited()
+
+    reply_recipients = await db_session.execute(
+        select(MessageRecipient)
+        .join(MessageRecipient.message)
+        .where(
+            MessageRecipient.recipient_staff_id == sender.id,
+            MessageRecipient.message.has(message_type=MessageType.inquiry_reply),
+        )
+    )
+    assert reply_recipients.scalars().first() is not None

--- a/tests/api/v1/test_app_admin_authorization_regression.py
+++ b/tests/api/v1/test_app_admin_authorization_regression.py
@@ -1,0 +1,44 @@
+from datetime import timedelta
+
+import pytest
+from httpx import AsyncClient
+
+from app.core.security import create_access_token
+
+
+ADMIN_GET_ENDPOINTS = [
+    "/api/v1/admin/audit-logs",
+    "/api/v1/admin/inquiries",
+    "/api/v1/admin/offices",
+    "/api/v1/admin/announcements",
+    "/api/v1/admin/archived-staffs/",
+]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("endpoint", ADMIN_GET_ENDPOINTS)
+async def test_admin_get_endpoints_reject_non_app_admin(
+    async_client: AsyncClient,
+    owner_user_factory,
+    endpoint: str,
+):
+    owner = await owner_user_factory()
+    access_token = create_access_token(str(owner.id), timedelta(minutes=30))
+
+    response = await async_client.get(
+        endpoint,
+        headers={"Authorization": f"Bearer {access_token}"},
+    )
+
+    assert response.status_code == 403
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("endpoint", ADMIN_GET_ENDPOINTS)
+async def test_admin_get_endpoints_reject_unauthenticated(
+    async_client: AsyncClient,
+    endpoint: str,
+):
+    response = await async_client.get(endpoint)
+
+    assert response.status_code == 401

--- a/tests/api/v1/test_message_inbox_filters.py
+++ b/tests/api/v1/test_message_inbox_filters.py
@@ -1,0 +1,50 @@
+from datetime import timedelta
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.security import create_access_token
+from app.crud.crud_message import crud_message
+from app.models.enums import MessagePriority, MessageType
+
+
+@pytest.mark.asyncio
+async def test_inbox_filters_by_multiple_message_types(
+    async_client: AsyncClient,
+    db_session: AsyncSession,
+    employee_user_factory,
+):
+    sender = await employee_user_factory()
+    office = sender.office_associations[0].office
+    recipient = await employee_user_factory(office=office)
+
+    for message_type in [MessageType.announcement, MessageType.inquiry_reply, MessageType.personal]:
+        await crud_message.create_personal_message(
+            db=db_session,
+            obj_in={
+                "sender_staff_id": sender.id,
+                "office_id": office.id,
+                "recipient_ids": [recipient.id],
+                "message_type": message_type,
+                "priority": MessagePriority.normal,
+                "title": f"{message_type.value} title",
+                "content": "本文",
+            },
+        )
+    await db_session.commit()
+
+    access_token = create_access_token(str(recipient.id), timedelta(minutes=30))
+    response = await async_client.get(
+        "/api/v1/messages/inbox",
+        params=[
+            ("message_types", "announcement"),
+            ("message_types", "inquiry_reply"),
+            ("limit", "20"),
+        ],
+        headers={"Authorization": f"Bearer {access_token}"},
+    )
+
+    assert response.status_code == 200
+    message_types = {item["message_type"] for item in response.json()["messages"]}
+    assert message_types == {"announcement", "inquiry_reply"}


### PR DESCRIPTION
## Summary
- お知らせや問い合わせへの返信について、複数のメッセージタイプに対応した受信トレイのフィルタリング機能を追加する
- アプリ管理者の問い合わせリストのデータと、返信の配信動作を整合させる
- アプリ管理者の「お知らせ」の受信者ルールを厳格化し、回帰テストのカバレッジを拡大する

## Validation
- Docker backend pytest with postgresql+psycopg://: 19 passed, 1 deselected, 5 warnings
- command: pytest tests/api/v1/test_message_inbox_filters.py tests/api/v1/test_admin_inquiry_reply_delivery.py tests/api/v1/test_admin_announcements.py tests/api/v1/test_app_admin_authorization_regression.py -m 'not performance' -q

Note: /app bind mount currently raises Errno 24 in this shared Docker container, so validation was run from a /tmp copy inside the same backend container.