### PR TITLE
fix: stabilize archived staff anonymization test

### DIFF
--- a/tests/crud/test_crud_archived_staff.py
+++ b/tests/crud/test_crud_archived_staff.py
@@ -117,11 +117,11 @@ class TestCRUDArchivedStaff:
         assert "john.doe" not in archive.anonymized_email
         assert "example.com" not in archive.anonymized_email
 
-        # 匿名化IDが9文字の英数字（SHA-256の先頭9文字）
+        # 匿名化IDが9文字の英数字（SHA-256 hexの先頭9文字を大文字化）
         anon_id = archive.anonymized_full_name.replace("スタッフ-", "")
         assert len(anon_id) == 9
         assert anon_id.isalnum()
-        assert anon_id.isupper()
+        assert anon_id == anon_id.upper()
 
     async def test_create_from_staff_with_office(self, db_session):
         """


### PR DESCRIPTION
## Summary
- SHAから導出された匿名化IDが数字のみで構成されている場合、アーカイブされたスタッフの匿名化テストを安定化させる。

## Background
- CD pytest failed because `str.isupper()` returns false for numeric-only strings such as `331493916`.
- The implementation uppercases SHA-256 hex output; numeric-only IDs are valid and contain no lowercase characters.

## Checks
- `docker compose exec backend pytest tests/crud/test_crud_archived_staff.py::TestCRUDArchivedStaff::test_anonymization`
- Result: 1 passed in 15.47s
