### PR TITLE
[codex] Fix PDF filename sanitization

### DIFF
--- a/app/api/v1/endpoints/support_plans.py
+++ b/app/api/v1/endpoints/support_plans.py
@@ -29,9 +29,20 @@ PDF_READ_CHUNK_BYTES = 1024 * 1024
 
 def sanitize_pdf_filename(filename: str | None) -> str:
     """S3 object名に含める元ファイル名を最小限サニタイズする。"""
-    safe_name = (filename or "unknown.pdf").split("/")[-1].split("\\")[-1]
-    safe_name = re.sub(r"[^A-Za-z0-9._-]", "_", safe_name).strip("._")
+    original_name = (filename or "unknown.pdf").split("/")[-1].split("\\")[-1]
+    name_part, dot, extension = original_name.rpartition(".")
+    if dot and extension.lower() == "pdf":
+        safe_stem = re.sub(r"[^A-Za-z0-9._-]", "_", name_part).strip("._")
+        return f"{safe_stem or 'file'}.pdf"
+
+    safe_name = re.sub(r"[^A-Za-z0-9._-]", "_", original_name).strip("._")
     return safe_name or "unknown.pdf"
+
+
+def get_original_pdf_filename(filename: str | None) -> str:
+    """画面表示用の元ファイル名からパス要素だけを除去する。"""
+    original_name = (filename or "unknown.pdf").split("/")[-1].split("\\")[-1]
+    return original_name or "unknown.pdf"
 
 
 def validate_pdf_upload(file_content: bytes, filename: str | None, content_type: str | None) -> None:
@@ -251,6 +262,7 @@ async def upload_plan_deliverable(
 
     # 5. ファイル名の衝突を避けるためにUUIDを付与
     safe_filename = sanitize_pdf_filename(file.filename)
+    original_filename = get_original_pdf_filename(file.filename)
     unique_filename = f"{uuid_lib.uuid4()}_{safe_filename}"
     object_name = f"plan-deliverables/{plan_cycle_id}/{deliverable_type}/{unique_filename}"
 
@@ -269,7 +281,7 @@ async def upload_plan_deliverable(
         plan_cycle_id=plan_cycle_id,
         deliverable_type=DeliverableType(deliverable_type),
         file_path=s3_url,
-        original_filename=safe_filename
+        original_filename=original_filename
     )
 
     deliverable = await support_plan_service.handle_deliverable_upload(
@@ -377,6 +389,7 @@ async def update_plan_deliverable(
 
     # 6. ファイル名の衝突を避けるためにUUIDを付与
     safe_filename = sanitize_pdf_filename(file.filename)
+    original_filename = get_original_pdf_filename(file.filename)
     unique_filename = f"{uuid_lib.uuid4()}_{safe_filename}"
     object_name = f"plan-deliverables/{deliverable.plan_cycle_id}/{deliverable.deliverable_type.value}/{unique_filename}"
 
@@ -395,7 +408,7 @@ async def update_plan_deliverable(
         db=db,
         deliverable_id=deliverable_id,
         new_file_path=s3_url,
-        new_filename=safe_filename
+        new_filename=original_filename
     )
 
     return updated_deliverable

--- a/tests/api/v1/test_plan_deliverables_s3.py
+++ b/tests/api/v1/test_plan_deliverables_s3.py
@@ -154,7 +154,7 @@ async def test_upload_pdf_with_s3_integration(
     # 3. PDFファイルのアップロード
     pdf_content = b"%PDF-1.4 mock content for S3 test"
     files = {
-        "file": ("assessment.pdf", io.BytesIO(pdf_content), "application/pdf")
+        "file": ("画面遷移要件.pdf", io.BytesIO(pdf_content), "application/pdf")
     }
     data = {
         "plan_cycle_id": cycle.id,
@@ -178,10 +178,13 @@ async def test_upload_pdf_with_s3_integration(
     # file_pathがS3 URLの形式であることを確認
     assert deliverable.file_path.startswith("s3://")
     assert settings.S3_BUCKET_NAME in deliverable.file_path
+    assert deliverable.original_filename == "画面遷移要件.pdf"
 
     # 6. S3に実際にファイルがアップロードされたことを確認
     # file_pathから object_name を抽出 (s3://bucket-name/object-name)
     object_name = deliverable.file_path.replace(f"s3://{settings.S3_BUCKET_NAME}/", "")
+    assert object_name.endswith("_file.pdf")
+    assert "画面遷移要件" not in object_name
 
     s3_response = s3_mock.get_object(Bucket=settings.S3_BUCKET_NAME, Key=object_name)
     s3_data = s3_response["Body"].read()

--- a/tests/api/v1/test_support_plan_pdf_upload_validation.py
+++ b/tests/api/v1/test_support_plan_pdf_upload_validation.py
@@ -1,0 +1,27 @@
+import pytest
+from fastapi import HTTPException
+
+from app.api.v1.endpoints.support_plans import (
+    get_original_pdf_filename,
+    sanitize_pdf_filename,
+    validate_pdf_upload,
+)
+
+
+def test_sanitize_pdf_filename_keeps_safe_pdf_extension_for_japanese_name():
+    assert sanitize_pdf_filename("画面遷移要件.pdf") == "file.pdf"
+
+
+def test_get_original_pdf_filename_keeps_japanese_display_name():
+    assert get_original_pdf_filename("画面遷移要件.pdf") == "画面遷移要件.pdf"
+
+
+def test_validate_pdf_upload_accepts_japanese_pdf_filename():
+    try:
+        validate_pdf_upload(
+            b"%PDF-1.7\n%%EOF",
+            "画面遷移要件.pdf",
+            "application/pdf",
+        )
+    except HTTPException as exc:
+        pytest.fail(f"valid Japanese PDF filename was rejected: {exc.detail}")


### PR DESCRIPTION
## Summary
- PDFアップロードファイル名のサニタイズ処理を行う際、.pdf 拡張子を保持する
- 「画面遷移要件.pdf」などの日本語のPDFファイル名に対する回帰テストを追加する

## Root cause
Japanese filename characters were converted to underscores and then stripped together with dots. For 画面遷移要件.pdf, the sanitized filename became pdf, so validation rejected it because it no longer ended with .pdf.

## Validation
- docker compose exec backend pytest tests/api/v1/test_support_plan_pdf_upload_validation.py -q
- docker compose exec backend pytest tests/api/v1/test_plan_deliverables_s3.py::test_upload_pdf_with_s3_integration -q