### PR TITLE
[codex] Refresh backend README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,38 +1,116 @@
-# fastAPI + neon
----
+# けいかくん Backend
 
-## **アプリケーションバックエンド要件定義書: ケイカくん API**
+FastAPI で実装された、けいかくんのバックエンド API です。認証、MFA、事業所、スタッフ、利用者、支援計画、PDF成果物、通知、課金、外部連携を扱います。
 
-### 1. システム概要とアーキテクチャ
+## 技術スタック
 
-#### 1.1. 目的
-本バックエンドは、福祉サービス事業所向けWebアプリケーション「ケイカくん」のサーバーサイド機能を提供する。主な責務は、データ永続化、ビジネスロジックの実行、フロントエンドへのAPI提供、外部サービスとの連携である。
+- Python 3.12
+- FastAPI
+- SQLAlchemy 2.x async ORM
+- Alembic
+- Pydantic v2
+- PostgreSQL / Neon
+- Stripe
+- AWS S3
+- Web Push
+- Google Calendar API
+- Google Cloud Run / Cloud Build
 
-#### 1.2. 技術スタック
-*   **フレームワーク**: FastAPI
-*   **言語**: Python 3.12+
-*   **データベース**: Neon (PostgreSQL)
-*   **ORM**: SQLAlchemy 2.0 (非同期モード)
-*   **DBマイグレーション**: Alembic
-*   **データ検証**: Pydantic V2
-*   **コンテナ化**: Docker
-*   **デプロイ先**: Google Cloud Run
+## アプリケーション構成
 
-#### 1.3. アーキテクチャ
-厳格な**階層型アーキテクチャ（Layered Architecture）**を採用し、関心の分離を徹底する。
+```text
+app/
+├── api/v1/endpoints/       # HTTP, auth, request validation, response shaping
+├── services/               # business use cases and transaction boundaries
+│   ├── approval/
+│   ├── billing/
+│   ├── calendar/
+│   └── welfare_recipient/
+├── crud/                   # focused data access
+├── models/                 # SQLAlchemy models and enums
+├── schemas/                # Pydantic schemas
+├── core/                   # settings, auth, security, integrations
+├── messages/               # centralized Japanese messages
+├── scheduler/              # scheduled jobs
+├── tasks/                  # batch task entry points
+└── templates/email/        # email templates
+```
 
-*   **API層 (`endpoints`)**: HTTPリクエストの受付とレスポンス返却に専念。認証・認可を処理し、リクエストを検証後、サービス層に処理を委譲する。
-*   **サービス層 (`services`)**: ビジネスロジックの中核。複数のCRUD操作を組み合わせて単一のユースケースを実装し、トランザクションを管理する。
-*   **CRUD層 (`crud`)**: データアクセス層。単一のDBモデルに対する基本的なCRUD操作のみを提供する。
-*   **スキーマ層 (`schemas`)**: Pydanticを使用し、APIの入出力や層間でのデータ転送オブジェクト（DTO）を厳密に定義する。
+## ロール
 
-### 2. 認証・認可要件
+現行ロールは次の4種類です。
 
-#### 2.1. 認証方式
-*   自前実装による**JWT (JSON Web Token) ベースのトークン認証**を採用する。
-*   パスワードは`passlib`と`bcrypt`アルゴリズムを用いてハッシュ化し、データベースに保存する。平文での保存は禁止する。
+- `owner`: 事業所管理者。事業所設定、スタッフ管理、課金、主要データ操作を行います。
+- `manager`: 利用者や支援計画の通常管理を行います。
+- `employee`: 参照と一部操作申請を行います。制限対象操作は承認フローに回します。
+- `app_admin`: アプリ運営者向けロールです。事業所横断の管理、退会申請、お知らせ、監査ログなどを扱います。
 
-#### 2.2. ユーザーロール（権限）
-システムは以下の3つのロールを管理し、APIエンドポイントごとにアクセス制御を行う。
-*   `service_administrator`: 全機能へのアクセス権を持つ最高責任者。
-*   `manager`:
+## 開発コマンド
+
+バックエンドコマンドは親リポジトリから Docker Compose の `backend` サービス内で実行します。
+
+```bash
+docker compose up -d backend
+docker compose exec backend alembic upgrade head
+docker compose exec backend pytest
+```
+
+個別テストの例です。
+
+```bash
+docker compose exec backend pytest tests/api/v1/test_csrf_protection.py
+docker compose exec backend pytest tests/api/v1/test_csrf_protection.py -m "not performance"
+```
+
+よく使う確認コマンドです。
+
+```bash
+docker compose exec backend sh -lc 'rg "await db.commit\\(|await db.flush\\(" app/api/v1/endpoints'
+docker compose exec backend sh -lc 'rg "print\\(" app --type py'
+docker compose exec backend sh -lc 'rg "HTTPException.*detail=\"[A-Za-z]" app/api --type py'
+docker compose exec backend sh -lc 'alembic heads && alembic current'
+```
+
+## マイグレーション
+
+DB 定義変更は Alembic migration を `migrations/versions/` に追加します。
+
+```bash
+docker compose exec backend alembic revision --autogenerate -m "describe_change"
+docker compose exec backend alembic upgrade head
+```
+
+enum、制約、カラム、インデックス、データ移行を含む変更では、PR に検証手順や件数確認を記載します。通常の開発や CI で `alembic stamp` は使いません。
+
+## 環境変数
+
+代表的な値です。実際の必須値は `app/core/config.py`、GitHub Actions、`cloudbuild.yml` を確認してください。
+
+- `DATABASE_URL`
+- `TEST_DATABASE_URL`
+- `SECRET_KEY`
+- `ENCRYPTION_KEY`
+- `CALENDAR_ENCRYPTION_KEY`
+- `BACKEND_CORS_ORIGINS`
+- `COOKIE_DOMAIN`, `COOKIE_SECURE`, `COOKIE_SAMESITE`
+- `STRIPE_SECRET_KEY`, `STRIPE_WEBHOOK_SECRET`, `STRIPE_PRICE_ID`
+- `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_REGION`, `S3_BUCKET_NAME`
+- `MAIL_USERNAME`, `MAIL_PASSWORD`, `MAIL_FROM`
+- `VAPID_PRIVATE_KEY`, `VAPID_PUBLIC_KEY`, `VAPID_SUBJECT`
+- `GOOGLE_CLIENT_ID`, `GOOGLE_CLIENT_SECRET`
+
+Stripe の現行サブスクリプション価格は月額6,000円です。価格変更は Stripe 側の Price と `STRIPE_PRICE_ID` の整合性を確認して行います。
+
+## 実装ルール
+
+- API 層は HTTP、認証認可、入力検証、レスポンス整形に集中します。
+- 複数モデルや複数 CRUD をまたぐ業務処理は service 層に置きます。
+- API 層に新しい `await db.commit()` / `await db.flush()` を追加しません。
+- CRUD は単一モデルまたは狭い集約のデータアクセスに留めます。
+- ユーザー向けエラーメッセージは日本語にし、可能な限り `app/messages/ja.py` に寄せます。
+- 本番コードで `print()` を使いません。
+- トークン、Cookie、個人情報、Stripe secret、Google credential、MFA secret、PDF ファイル名などをログに出しません。
+
+## CI/CD
+
+Backend は parent repository の GitHub Actions からテストを実行し、Cloud Build 経由で Cloud Run にデプロイします。Cloud Build の本番環境変数は `cloudbuild.yml` の `--update-env-vars` を更新します。


### PR DESCRIPTION
## Summary
- バックエンドのREADMEを最新の開発者ガイドとして書き直す
- 現在の役割（オーナー、マネージャー、従業員、app_admin）を文書化する
- 従来のホストコマンドをDocker Composeのバックエンドコマンドに置き換える
- 現在のStripeのサブスクリプション料金を月額6,000円として記載する

## Validation
- rg check confirmed stale role/path/library/price terms are removed from README files
- git diff --check passed

Related to nto300002/keikakun_app#184